### PR TITLE
feat: update analytics requirements, split leaderboard analytics

### DIFF
--- a/lambda/src/endpoints/analytics/handler.py
+++ b/lambda/src/endpoints/analytics/handler.py
@@ -1,0 +1,34 @@
+import json
+from ...utils.utils import build_response
+
+from .leaderboard import get_leaderboard, get_user_entry
+
+
+def handle(event):
+    """
+    Single endpoint to handle various analytics queries.
+    Routes to the appropriate processor based on the 'queryType' in the request body.
+    """
+    try:
+        body = json.loads(event.get("body", "{}"))
+        query_type = body.get("queryType")
+
+        if not query_type:
+            return build_response(
+                400, {"error": "Request body must include 'queryType'"}
+            )
+
+        # Route to the imported functions
+        if query_type == "leaderboard":
+            return get_leaderboard(body)
+        elif query_type == "user_leaderboard_entry":
+            return get_user_entry(body)
+
+        else:
+            return build_response(400, {"error": f"Unknown queryType: '{query_type}'"})
+
+    except json.JSONDecodeError:
+        return build_response(400, {"error": "Invalid JSON body"})
+    except Exception as e:
+        print(f"An unexpected error occurred in handle_analytics: {str(e)}")
+        return build_response(500, {"error": "An internal server error occurred"})

--- a/lambda/src/lambda_handler.py
+++ b/lambda/src/lambda_handler.py
@@ -1,7 +1,8 @@
 import json
 from .utils.rate_limitter import rate_limit
 from .utils.utils import build_response
-from .endpoints import evm, solana, sui, prices, metrics, analytics
+from .endpoints import evm, solana, sui, prices, metrics
+from .endpoints.analytics import handler as analytics_handler
 
 
 def lambda_handler(event, context):
@@ -86,7 +87,7 @@ def lambda_handler(event, context):
 
     elif path == "/analytics" or path.endswith("/analytics"):
         if event["httpMethod"] == "POST":
-            return analytics.handle(event)
+            return analytics_handler.handle(event)
 
     # 404 Not Found
     return build_response(404, {"error": "Not found"})

--- a/notes/analytics_required.md
+++ b/notes/analytics_required.md
@@ -3,9 +3,11 @@
 | Metric Category | Metric Name | Description / Calculation (Based on your Schema) | Suggested Chart Type |
 | :--- | :--- | :--- | :--- |
 | **User & Audience** | Total Users | `COUNT` of all `user_stats` items. | **KPI Scorecard** (Big Number) |
-| **User &Audience** | New Users (Time-series) | `COUNT` of `user_stats` items, grouped by `first_active_timestamp` (Daily, Weekly, Monthly). | **Line Chart** or **Bar Chart** |
+| **User & Audience** | New Users (Time-series) | `COUNT` of `user_stats` items, grouped by `first_active_timestamp` (Daily, Weekly, Monthly). | **Line Chart** or **Bar Chart** |
 | **User & Audience** | Active Users (DAU/WAU/MAU) | `COUNT` of unique users with any event (`swap`, `lending`, `earn`, `entrance`) in the period. | **Line Chart** |
 | **User & Audience** | User Segmentation | Breakdown of users by `total_swap_count > 0` vs. `total_lending_count > 0` vs. `total_earn_count > 0`. | **Venn Diagram** or **Donut Chart** |
+| **User & Audience** | New User Growth Rate | `(New Users this Period / Total Users last Period) * 100%`. | **Line Chart** or **KPI Scorecard** |
+| **User & Audience** | Retention Cohorts | `%` of new users from "Week 1" who returned in "Week 2", "Week 3", etc. | **Heatmap Table** (Cohort Table) |
 | **Overall Activity** | Total Transactions | `SUM` of all `swap`, `lending`, and `earn` items. | **KPI Scorecard** (Big Number) |
 | **Overall Activity** | Transaction Volume (Time-series) | `COUNT` of all transactions (`swap`, `lending`, `earn`) per day/week/month. | **Line Chart** or **Bar Chart** |
 | **Overall Activity** | Activity Breakdown | Stacked bar chart (one bar per day/week) showing `swap_count`, `lending_count`, and `earn_count`. | **Stacked Bar Chart** |
@@ -19,13 +21,9 @@
 | **Lending Metrics** | Lending Market Breakdown | `COUNT` of transactions for each `market_name`. | **Bar Chart** or **Donut Chart** (Top 5 + "Other") |
 | **Lending Metrics** | Popular Lending Chains | `COUNT` grouped by `chain`. | **Donut Chart** or **Bar Chart** |
 | **Lending Metrics** | Lending Assets Breakdown | `COUNT` of transactions for each `token_symbol`. | **Bar Chart** or **Donut Chart** (Top 5 + "Other") |
-| **Growth & Retention** | New User Growth Rate | `(New Users this Period / Total Users last Period) * 100%`. | **Line Chart** or **KPI Scorecard** |
-| **Growth & Retention** | Retention Cohorts | `%` of new users from "Week 1" who returned in "Week 2", "Week 3", etc. | **Heatmap Table** (Cohort Table) |
-| | | | |
+| **Earn Metrics** | Earn Action Breakdown | `COUNT` of earn actions, grouped by `action` (`stake`, `unstake`, `claim`). | **Donut Chart** or **Bar Chart** |
+| **Earn Metrics** | Popular Earn Protocols | `COUNT` grouped by `protocol`. | **Donut Chart** or **Bar Chart** |
+| **Earn Metrics** | Popular Earn Chains | `COUNT` grouped by `chain`. | **Donut Chart** or **Bar Chart** |
+| **Earn Metrics** | Vault Breakdown | `COUNT` of transactions for each `vault_name`. | **Bar Chart** or **Donut Chart** (Top 5 + "Other") |
 | **Leaderboard Displays** | Weekly Leaderboard | A view of the `leaderboard-by-xp-gsi` for the current `week`, sorted by `xp` (DESC). | **Table** |
 | **Leaderboard Displays** | Global Leaderboard | A view of the `global-leaderboard-by-xp-gsi`, sorted by `total_xp` (DESC). | **Table** |
-| | | | |
-| **Low Priority** | Earn Action Breakdown | `COUNT` of earn actions, grouped by `action` (`stake`, `unstake`, `claim`). | **Donut Chart** or **Bar Chart** |
-| **Low Priority** | Popular Earn Protocols | `COUNT` grouped by `protocol`. | **Donut Chart** or **Bar Chart** |
-| **Low Priority** | Popular Earn Chains | `COUNT` grouped by `chain`. | **Donut Chart** or **Bar Chart** |
-| **Low Priority** | Vault Breakdown | `COUNT` of transactions for each `vault_name`. | **Bar Chart** or **Donut Chart** (Top 5 + "Other") |

--- a/notes/analytics_required.md
+++ b/notes/analytics_required.md
@@ -6,8 +6,6 @@
 | **User & Audience** | New Users (Time-series) | `COUNT` of `user_stats` items, grouped by `first_active_timestamp` (Daily, Weekly, Monthly). | **Line Chart** or **Bar Chart** |
 | **User & Audience** | Active Users (DAU/WAU/MAU) | `COUNT` of unique users with any event (`swap`, `lending`, `earn`, `entrance`) in the period. | **Line Chart** |
 | **User & Audience** | User Segmentation | Breakdown of users by `total_swap_count > 0` vs. `total_lending_count > 0` vs. `total_earn_count > 0`. | **Venn Diagram** or **Donut Chart** |
-| **User & Audience** | New User Growth Rate | `(New Users this Period / Total Users last Period) * 100%`. | **Line Chart** or **KPI Scorecard** |
-| **User & Audience** | Retention Cohorts | `%` of new users from "Week 1" who returned in "Week 2", "Week 3", etc. | **Heatmap Table** (Cohort Table) |
 | **Overall Activity** | Total Transactions | `SUM` of all `swap`, `lending`, and `earn` items. | **KPI Scorecard** (Big Number) |
 | **Overall Activity** | Transaction Volume (Time-series) | `COUNT` of all transactions (`swap`, `lending`, `earn`) per day/week/month. | **Line Chart** or **Bar Chart** |
 | **Overall Activity** | Activity Breakdown | Stacked bar chart (one bar per day/week) showing `swap_count`, `lending_count`, and `earn_count`. | **Stacked Bar Chart** |
@@ -27,3 +25,10 @@
 | **Earn Metrics** | Vault Breakdown | `COUNT` of transactions for each `vault_name`. | **Bar Chart** or **Donut Chart** (Top 5 + "Other") |
 | **Leaderboard Displays** | Weekly Leaderboard | A view of the `leaderboard-by-xp-gsi` for the current `week`, sorted by `xp` (DESC). | **Table** |
 | **Leaderboard Displays** | Global Leaderboard | A view of the `global-leaderboard-by-xp-gsi`, sorted by `total_xp` (DESC). | **Table** |
+
+## Expensive Exclusions
+
+| Metric Category | Metric Name | Description / Calculation (Based on your Schema) | Suggested Chart Type |
+| :--- | :--- | :--- | :--- |
+| **User & Audience** | New User Growth Rate | `(New Users this Period / Total Users last Period) * 100%`. | **Line Chart** or **KPI Scorecard** |
+| **User & Audience** | Retention Cohorts | `%` of new users from "Week 1" who returned in "Week 2", "Week 3", etc. | **Heatmap Table** (Cohort Table) |

--- a/notes/analytics_required.md
+++ b/notes/analytics_required.md
@@ -1,34 +1,39 @@
-## Captured Analytics
+### Captured Analytics (Real-time)
 
-| Metric Category | Metric Name | Description / Calculation (Based on your Schema) | Suggested Chart Type |
+This list includes metrics that can be pulled **instantly** from aggregated `STAT` items, making them suitable for a fast-loading public dashboard. The 'Description' column details the efficient query pattern.
+
+| Metric Category | Metric Name | Description / Calculation (Based on Schema) | Chart Type |
 | :--- | :--- | :--- | :--- |
-| **User & Audience** | Total Users | `COUNT` of all `user_stats` items. | **KPI Scorecard** (Big Number) |
-| **User & Audience** | New Users (Time-series) | `COUNT` of `user_stats` items, grouped by `first_active_timestamp` (Daily, Weekly, Monthly). | **Line Chart** or **Bar Chart** |
-| **User & Audience** | Active Users (DAU/WAU/MAU) | `COUNT` of unique users with any event (`swap`, `lending`, `earn`, `entrance`) in the period. | **Line Chart** |
-| **User & Audience** | User Segmentation | Breakdown of users by `total_swap_count > 0` vs. `total_lending_count > 0` vs. `total_earn_count > 0`. | **Venn Diagram** or **Donut Chart** |
-| **Overall Activity** | Total Transactions | `SUM` of all `swap`, `lending`, and `earn` items. | **KPI Scorecard** (Big Number) |
-| **Overall Activity** | Transaction Volume (Time-series) | `COUNT` of all transactions (`swap`, `lending`, `earn`) per day/week/month. | **Line Chart** or **Bar Chart** |
-| **Overall Activity** | Activity Breakdown | Stacked bar chart (one bar per day/week) showing `swap_count`, `lending_count`, and `earn_count`. | **Stacked Bar Chart** |
-| **Overall Activity** | dApp Entrances (Time-series) | `COUNT` of `entrance` events, grouped by day, week, and month. | **Line Chart** or **Bar Chart** |
-| **Overall Activity** | Transactions per Active User | `Total Transactions` in period / `Active Users` in period. | **Line Chart** or **KPI Scorecard** |
-| **Swap Metrics** | Total Swap Count | `COUNT` of all `swap` items. | **KPI Scorecard** (Big Number) |
-| **Swap Metrics** | Swap Pair Breakdown | `COUNT` for each `source_token_symbol` -> `destination_token_symbol` combination. | **Bar Chart** or **Donut Chart** (Top 5 + "Other") |
-| **Swap Metrics** | Swap Routes (Chains) Breakdown | `COUNT` for each `source_chain` -> `destination_chain` combination. | **Bar Chart** or **Sankey Diagram** |
-| **Swap Metrics** | Cross-Chain vs. Same-Chain | `%` of swaps where `source_chain != destination_chain`. | **Donut Chart** or **100% Stacked Bar** |
-| **Lending Metrics** | Lending Action Breakdown | `COUNT` of lending actions, grouped by `action` (`deposit`, `withdraw`, `borrow`, `repay`). | **Donut Chart** or **Bar Chart** |
-| **Lending Metrics** | Lending Market Breakdown | `COUNT` of transactions for each `market_name`. | **Bar Chart** or **Donut Chart** (Top 5 + "Other") |
-| **Lending Metrics** | Popular Lending Chains | `COUNT` grouped by `chain`. | **Donut Chart** or **Bar Chart** |
-| **Lending Metrics** | Lending Assets Breakdown | `COUNT` of transactions for each `token_symbol`. | **Bar Chart** or **Donut Chart** (Top 5 + "Other") |
-| **Earn Metrics** | Earn Action Breakdown | `COUNT` of earn actions, grouped by `action` (`stake`, `unstake`, `claim`). | **Donut Chart** or **Bar Chart** |
-| **Earn Metrics** | Popular Earn Protocols | `COUNT` grouped by `protocol`. | **Donut Chart** or **Bar Chart** |
-| **Earn Metrics** | Popular Earn Chains | `COUNT` grouped by `chain`. | **Donut Chart** or **Bar Chart** |
-| **Earn Metrics** | Vault Breakdown | `COUNT` of transactions for each `vault_name`. | **Bar Chart** or **Donut Chart** (Top 5 + "Other") |
-| **Leaderboard Displays** | Weekly Leaderboard | A view of the `leaderboard-by-xp-gsi` for the current `week`, sorted by `xp` (DESC). | **Table** |
-| **Leaderboard Displays** | Global Leaderboard | A view of the `global-leaderboard-by-xp-gsi`, sorted by `total_xp` (DESC). | **Table** |
+| **User & Audience** | **Total Users** | `Get` `STAT#all#ALL` item. <br> Read the **`new_users`** attribute. | KPI Scorecard |
+| **User & Audience** | New Users (Time-series) | `Get` `STAT#{period}#GENERAL` item. <br> Read the **`new_users`** attribute. | Line/Bar Chart |
+| **User & Audience** | Active Users (DAU/WAU/MAU) | `Get` `STAT#{period}#GENERAL` item. <br> Read the **`active_users`** attribute. | Line Chart |
+| **Overall Activity** | **Total Transactions** | `Get` `STAT#all#ALL` item. <br> Calculate **`swap_count + lending_count + earn_count`**. | KPI Scorecard |
+| **Overall Activity** | Transaction Volume (Time-series) | `Get` `STAT#{period}#GENERAL` item. <br> Calculate **`swap_count + lending_count + earn_count`**. | Line/Bar Chart |
+| **Overall Activity** | Activity Breakdown (Time-series) | `Get` `STAT#{period}#GENERAL` item. <br> Read **`swap_count`**, **`lending_count`**, and **`earn_count`** attributes. | Stacked Bar Chart |
+| **Overall Activity** | dApp Entrances (Time-series) | `Get` `STAT#{period}#GENERAL` item. <br> Read the **`dapp_entrances`** attribute. | Line/Bar Chart |
+| **Overall Activity** | Transactions per Active User | `Get` `STAT#{period}#GENERAL` item. <br> Calculate **`(swap_count + lending_count + earn_count) / active_users`**. | Line Chart / KPI |
+| **Swap Metrics** | **Total Swap Count** | `Get` `STAT#all#ALL` item. <br> Read the **`swap_count`** attribute. | KPI Scorecard |
+| **Swap Metrics** | Swap Routes (Chains) Breakdown | `Query` `PK = STAT#{period}` and `SK starts_with "SWAP#"`. <br> Aggregate results from all `periodic_swap_stats` items. | Sankey Diagram / Bar Chart |
+| **Swap Metrics** | Cross-Chain vs. Same-Chain | `Query` `PK = STAT#{period}` and `SK starts_with "SWAP#"`. <br> Backend logic parses the `SK` (`SWAP#{source}#{dest}`) to sum `count` for `source != dest` vs. `source == dest`. | Donut Chart |
+| **Lending Metrics** | **Total Lending Count** | `Get` `STAT#all#ALL` item. <br> Read the **`lending_count`** attribute. | KPI Scorecard |
+| **Lending Metrics** | Lending Market/Chain Breakdown | `Query` `PK = STAT#{period}` and `SK starts_with "LENDING#"`. <br> Backend logic parses the `SK` (`LENDING#{chain}#{market}`) to aggregate `count` by chain or market. | Bar Chart / Donut Chart |
+| **Earn Metrics** | **Total Earn Count** | `Get` `STAT#all#ALL` item. <br> Read the **`earn_count`** attribute. | KPI Scorecard |
+| **Earn Metrics** | Earn Protocol/Chain Breakdown | `Query` `PK = STAT#{period}` and `SK starts_with "EARN#"`. <br> Backend logic parses the `SK` (`EARN#{chain}#{protocol}`) to aggregate `count` by chain or protocol. | Bar Chart / Donut Chart |
+| **Leaderboard** | Weekly Leaderboard | `Query` the **`leaderboard-by-xp-gsi`** with `PK = LEADERBOARD#{current_week}`. | Table |
+| **Leaderboard** | Global Leaderboard | `Query` the **`global-leaderboard-by-xp-gsi`** with `PK = "GLOBAL"`. | Table |
 
-## Expensive Exclusions
+-----
 
-| Metric Category | Metric Name | Description / Calculation (Based on your Schema) | Suggested Chart Type |
-| :--- | :--- | :--- | :--- |
-| **User & Audience** | New User Growth Rate | `(New Users this Period / Total Users last Period) * 100%`. | **Line Chart** or **KPI Scorecard** |
-| **User & Audience** | Retention Cohorts | `%` of new users from "Week 1" who returned in "Week 2", "Week 3", etc. | **Heatmap Table** (Cohort Table) |
+### Expensive / Offline Analytics
+
+This list includes metrics that **cannot** be answered by the real-time `STAT` items. They require full scans, GSI queries, or post-processing (e.g., with AWS Glue, Athena, or a batch Lambda) on the raw transaction data.
+
+| Metric Category | Metric Name | Reason for Offline Calculation |
+| :--- | :--- | :--- |
+| **User & Audience** | New User Growth Rate | Depends on "Total Users" (real-time) and periodic `new_users`, but calculation is typically done offline. |
+| **User & Audience** | Retention Cohorts | Requires finding users by `first_active_timestamp` and then checking their activity in subsequent periods. |
+| **Swap Metrics** | Swap Pair Breakdown (Tokens) | The `periodic_swap_stats` item is keyed by *chain*, not by `source_token_symbol` or `destination_token_symbol`. This requires querying the raw `swap` items. |
+| **Lending Metrics** | Lending Action Breakdown | The `periodic_lending_stats` item is keyed by `chain` and `market_name`, not by `action` (deposit, borrow, etc.). This requires querying the raw `lending` items. |
+| **Lending Metrics** | Lending Assets Breakdown | The `periodic_lending_stats` item does not include `token_symbol`. This requires querying the raw `lending` items. |
+| **Earn Metrics** | Earn Action Breakdown | The `periodic_earn_stats` item is keyed by `chain` and `protocol`, not by `action` (stake, unstake, etc.). This requires querying the raw `earn` items. |
+| **Earn Metrics** | Vault Breakdown | The `periodic_earn_stats` item does not include `vault_name`. This requires querying the raw `earn` items. |

--- a/notes/analytics_required.md
+++ b/notes/analytics_required.md
@@ -2,25 +2,25 @@
 
 This list includes metrics that can be pulled **instantly** from aggregated `STAT` items, making them suitable for a fast-loading public dashboard. The 'Description' column details the efficient query pattern.
 
-| Metric Category | Metric Name | Description / Calculation (Based on Schema) | Chart Type |
-| :--- | :--- | :--- | :--- |
-| **User & Audience** | **Total Users** | `Get` `STAT#all#ALL` item. <br> Read the **`new_users`** attribute. | KPI Scorecard |
-| **User & Audience** | New Users (Time-series) | `Get` `STAT#{period}#GENERAL` item. <br> Read the **`new_users`** attribute. | Line/Bar Chart |
-| **User & Audience** | Active Users (DAU/WAU/MAU) | `Get` `STAT#{period}#GENERAL` item. <br> Read the **`active_users`** attribute. | Line Chart |
-| **Overall Activity** | **Total Transactions** | `Get` `STAT#all#ALL` item. <br> Calculate **`swap_count + lending_count + earn_count`**. | KPI Scorecard |
-| **Overall Activity** | Transaction Volume (Time-series) | `Get` `STAT#{period}#GENERAL` item. <br> Calculate **`swap_count + lending_count + earn_count`**. | Line/Bar Chart |
-| **Overall Activity** | Activity Breakdown (Time-series) | `Get` `STAT#{period}#GENERAL` item. <br> Read **`swap_count`**, **`lending_count`**, and **`earn_count`** attributes. | Stacked Bar Chart |
-| **Overall Activity** | dApp Entrances (Time-series) | `Get` `STAT#{period}#GENERAL` item. <br> Read the **`dapp_entrances`** attribute. | Line/Bar Chart |
-| **Overall Activity** | Transactions per Active User | `Get` `STAT#{period}#GENERAL` item. <br> Calculate **`(swap_count + lending_count + earn_count) / active_users`**. | Line Chart / KPI |
-| **Swap Metrics** | **Total Swap Count** | `Get` `STAT#all#ALL` item. <br> Read the **`swap_count`** attribute. | KPI Scorecard |
-| **Swap Metrics** | Swap Routes (Chains) Breakdown | `Query` `PK = STAT#{period}` and `SK starts_with "SWAP#"`. <br> Aggregate results from all `periodic_swap_stats` items. | Sankey Diagram / Bar Chart |
-| **Swap Metrics** | Cross-Chain vs. Same-Chain | `Query` `PK = STAT#{period}` and `SK starts_with "SWAP#"`. <br> Backend logic parses the `SK` (`SWAP#{source}#{dest}`) to sum `count` for `source != dest` vs. `source == dest`. | Donut Chart |
-| **Lending Metrics** | **Total Lending Count** | `Get` `STAT#all#ALL` item. <br> Read the **`lending_count`** attribute. | KPI Scorecard |
-| **Lending Metrics** | Lending Market/Chain Breakdown | `Query` `PK = STAT#{period}` and `SK starts_with "LENDING#"`. <br> Backend logic parses the `SK` (`LENDING#{chain}#{market}`) to aggregate `count` by chain or market. | Bar Chart / Donut Chart |
-| **Earn Metrics** | **Total Earn Count** | `Get` `STAT#all#ALL` item. <br> Read the **`earn_count`** attribute. | KPI Scorecard |
-| **Earn Metrics** | Earn Protocol/Chain Breakdown | `Query` `PK = STAT#{period}` and `SK starts_with "EARN#"`. <br> Backend logic parses the `SK` (`EARN#{chain}#{protocol}`) to aggregate `count` by chain or protocol. | Bar Chart / Donut Chart |
-| **Leaderboard** | Weekly Leaderboard | `Query` the **`leaderboard-by-xp-gsi`** with `PK = LEADERBOARD#{current_week}`. | Table |
-| **Leaderboard** | Global Leaderboard | `Query` the **`global-leaderboard-by-xp-gsi`** with `PK = "GLOBAL"`. | Table |
+| Metric Category | Metric Name | Description / Calculation (Based on Schema) | Chart Type | Status |
+| :--- | :--- | :--- | :--- | :--- |
+| **User & Audience** | **Total Users** | `Get` `STAT#all#ALL` item. <br> Read the **`new_users`** attribute. | KPI Scorecard | ❌ |
+| **User & Audience** | New Users (Time-series) | `Get` `STAT#{period}#GENERAL` item. <br> Read the **`new_users`** attribute. | Line/Bar Chart | ❌ |
+| **User & Audience** | Active Users (DAU/WAU/MAU) | `Get` `STAT#{period}#GENERAL` item. <br> Read the **`active_users`** attribute. | Line Chart | ❌ |
+| **Overall Activity** | **Total Transactions** | `Get` `STAT#all#ALL` item. <br> Calculate **`swap_count + lending_count + earn_count`**. | KPI Scorecard | ❌ |
+| **Overall Activity** | Transaction Volume (Time-series) | `Get` `STAT#{period}#GENERAL` item. <br> Calculate **`swap_count + lending_count + earn_count`**. | Line/Bar Chart | ❌ |
+| **Overall Activity** | Activity Breakdown (Time-series) | `Get` `STAT#{period}#GENERAL` item. <br> Read **`swap_count`**, **`lending_count`**, and **`earn_count`** attributes. | Stacked Bar Chart | ❌ |
+| **Overall Activity** | dApp Entrances (Time-series) | `Get` `STAT#{period}#GENERAL` item. <br> Read the **`dapp_entrances`** attribute. | Line/Bar Chart | ❌ |
+| **Overall Activity** | Transactions per Active User | `Get` `STAT#{period}#GENERAL` item. <br> Calculate **`(swap_count + lending_count + earn_count) / active_users`**. | Line Chart / KPI | ❌ |
+| **Swap Metrics** | **Total Swap Count** | `Get` `STAT#all#ALL` item. <br> Read the **`swap_count`** attribute. | KPI Scorecard | ❌ |
+| **Swap Metrics** | Swap Routes (Chains) Breakdown | `Query` `PK = STAT#{period}` and `SK starts_with "SWAP#"`. <br> Aggregate results from all `periodic_swap_stats` items. | Sankey Diagram / Bar Chart | ❌ |
+| **Swap Metrics** | Cross-Chain vs. Same-Chain | `Query` `PK = STAT#{period}` and `SK starts_with "SWAP#"`. <br> Backend logic parses the `SK` (`SWAP#{source}#{dest}`) to sum `count` for `source != dest` vs. `source == dest`. | Donut Chart | ❌ |
+| **Lending Metrics** | **Total Lending Count** | `Get` `STAT#all#ALL` item. <br> Read the **`lending_count`** attribute. | KPI Scorecard | ❌ |
+| **Lending Metrics** | Lending Market/Chain Breakdown | `Query` `PK = STAT#{period}` and `SK starts_with "LENDING#"`. <br> Backend logic parses the `SK` (`LENDING#{chain}#{market}`) to aggregate `count` by chain or market. | Bar Chart / Donut Chart | ❌ |
+| **Earn Metrics** | **Total Earn Count** | `Get` `STAT#all#ALL` item. <br> Read the **`earn_count`** attribute. | KPI Scorecard | ❌ |
+| **Earn Metrics** | Earn Protocol/Chain Breakdown | `Query` `PK = STAT#{period}` and `SK starts_with "EARN#"`. <br> Backend logic parses the `SK` (`EARN#{chain}#{protocol}`) to aggregate `count` by chain or protocol. | Bar Chart / Donut Chart | ❌ |
+| **Leaderboard** | Weekly Leaderboard | `Query` the **`leaderboard-by-xp-gsi`** with `PK = LEADERBOARD#{current_week}`. | Table | ✅ |
+| **Leaderboard** | Global Leaderboard | `Query` the **`global-leaderboard-by-xp-gsi`** with `PK = "GLOBAL"`. | Table | ✅ |
 
 -----
 
@@ -28,12 +28,12 @@ This list includes metrics that can be pulled **instantly** from aggregated `STA
 
 This list includes metrics that **cannot** be answered by the real-time `STAT` items. They require full scans, GSI queries, or post-processing (e.g., with AWS Glue, Athena, or a batch Lambda) on the raw transaction data.
 
-| Metric Category | Metric Name | Reason for Offline Calculation |
-| :--- | :--- | :--- |
-| **User & Audience** | New User Growth Rate | Depends on "Total Users" (real-time) and periodic `new_users`, but calculation is typically done offline. |
-| **User & Audience** | Retention Cohorts | Requires finding users by `first_active_timestamp` and then checking their activity in subsequent periods. |
-| **Swap Metrics** | Swap Pair Breakdown (Tokens) | The `periodic_swap_stats` item is keyed by *chain*, not by `source_token_symbol` or `destination_token_symbol`. This requires querying the raw `swap` items. |
-| **Lending Metrics** | Lending Action Breakdown | The `periodic_lending_stats` item is keyed by `chain` and `market_name`, not by `action` (deposit, borrow, etc.). This requires querying the raw `lending` items. |
-| **Lending Metrics** | Lending Assets Breakdown | The `periodic_lending_stats` item does not include `token_symbol`. This requires querying the raw `lending` items. |
-| **Earn Metrics** | Earn Action Breakdown | The `periodic_earn_stats` item is keyed by `chain` and `protocol`, not by `action` (stake, unstake, etc.). This requires querying the raw `earn` items. |
-| **Earn Metrics** | Vault Breakdown | The `periodic_earn_stats` item does not include `vault_name`. This requires querying the raw `earn` items. |
+| Metric Category | Metric Name | Reason for Offline Calculation | Status |
+| :--- | :--- | :--- | :--- |
+| **User & Audience** | New User Growth Rate | Depends on "Total Users" (real-time) and periodic `new_users`, but calculation is typically done offline. | ❌ |
+| **User & Audience** | Retention Cohorts | Requires finding users by `first_active_timestamp` and then checking their activity in subsequent periods. | ❌ |
+| **Swap Metrics** | Swap Pair Breakdown (Tokens) | The `periodic_swap_stats` item is keyed by *chain*, not by `source_token_symbol` or `destination_token_symbol`. This requires querying the raw `swap` items. | ❌ |
+| **Lending Metrics** | Lending Action Breakdown | The `periodic_lending_stats` item is keyed by `chain` and `market_name`, not by `action` (deposit, borrow, etc.). This requires querying the raw `lending` items. | ❌ |
+| **Lending Metrics** | Lending Assets Breakdown | The `periodic_lending_stats` item does not include `token_symbol`. This requires querying the raw `lending` items. | ❌ |
+| **Earn Metrics** | Earn Action Breakdown | The `periodic_earn_stats` item is keyed by `chain` and `protocol`, not by `action` (stake, unstake, etc.). This requires querying the raw `earn` items. | ❌ |
+| **Earn Metrics** | Vault Breakdown | The `periodic_earn_stats` item does not include `vault_name`. This requires querying the raw `earn` items. | ❌ |

--- a/notes/metrics_schema.md
+++ b/notes/metrics_schema.md
@@ -16,7 +16,7 @@
 
 ## Global Secondary Indexes (GSIs)
 
-To support efficient, sorted queries for both weekly and global leaderboards, two GSIs are used.
+To support efficient, sorted queries for weekly/global leaderboards and offline analytics.
 
 ### Weekly Leaderboard GSI
 
@@ -30,11 +30,21 @@ This index allows for fetching a specific week's leaderboard, sorted by `xp` in 
 
 ### Global Leaderboard GSI
 
-This index enables a global, all-time leaderboard by querying across all users. It indexes the `user_stats` items. 
+This index enables a global, all-time leaderboard by querying across all users. It indexes the `user_stats` items.
 
 | GSI Name | GSI Partition Key | GSI Sort Key |
 | :--- | :--- | :--- |
 | `global-leaderboard-by-xp-gsi` | `leaderboard_scope` (String) | `total_xp` (Number) |
+
+---
+
+### Transaction Time-Series GSI
+
+This index enables efficient queries for offline analytics jobs (e.g., "fetch all lending transactions from the last 24 hours"). It indexes *only* the `swap`, `lending`, and `earn` items.
+
+| GSI Name | GSI Partition Key | GSI Sort Key |
+| :--- | :--- | :--- |
+| `transactions-by-time-gsi` | `tx_type` (String) | `timestamp` (String) |
 
 ---
 
@@ -56,6 +66,7 @@ This section outlines the specific attributes intended for capture within each d
 - `destination_token_symbol`
 - `amount_out`
 - `timestamp`
+- `tx_type` 
 
 ### Lending
 - `user_address`
@@ -68,6 +79,7 @@ This section outlines the specific attributes intended for capture within each d
 - `token_symbol`
 - `amount`
 - `timestamp`
+- `tx_type`
 
 ### Earn
 - `user_address`
@@ -81,6 +93,7 @@ This section outlines the specific attributes intended for capture within each d
 - `token_symbol`
 - `amount`
 - `timestamp`
+- `tx_type`
 
 ### User Stats
 - `user_address`

--- a/notes/metrics_schema.md
+++ b/notes/metrics_schema.md
@@ -106,37 +106,39 @@ This section outlines the specific attributes intended for capture within each d
 - `last_active_timestamp`
 
 ### Periodic General Stats
-- `period_start_date`
-- `period_type`
-- `swap_count`
-- `lending_count`
-- `earn_count`
-- `dapp_entrances`
-- `active_users`
-- `new_users`
+This item captures both periodic (daily, weekly, monthly) and global (all-time) metrics. The context is determined by the `PK` (`STAT#{period_type}#{period_start_date}`).
+
+- `period_start_date`: (e.g., `2023-10-27`, `2023-W43`, or `ALL`)
+- `period_type`: (e.g., `daily`, `weekly`, `monthly`, `all`)
+- `swap_count`: The count of swaps. (For `period_type=all`, this is the all-time total).
+- `lending_count`: The count of lending actions. (For `period_type=all`, this is the all-time total).
+- `earn_count`: The count of earn actions. (For `period_type=all`, this is the all-time total).
+- `dapp_entrances`: The count of entrances. (For `period_type=all`, this is the all-time total).
+- `active_users`: The count of unique active users for the period. (Not applicable for `period_type=all`).
+- `new_users`: The count of new users for the period. (For `period_type=all`, this represents the all-time total unique users).
 
 ### Periodic Swap Stats
-- `period_start_date`
-- `period_type`
-- `direction`
-- `count`
+- `period_start_date`: (e.g., `2023-10-27`, `2023-W43`, or `ALL`)
+- `period_type`: (e.g., `daily`, `weekly`, `monthly`, `all`)
+- `direction`: A string representing the source and destination chains (e.g., `ETH,ARB` or `BSC,BSC`).
+- `count`: The total count of swaps for this direction and period.
 
 ### Periodic Lending Stats
-- `period_start_date`
-- `period_type`
+- `period_start_date`: (e.g., `2023-10-27`, `2023-W43`, or `ALL`)
+- `period_type`: (e.g., `daily`, `weekly`, `monthly`, `all`)
 - `chain`
 - `market_name`
-- `count`
+- `count`: The total count of lending actions for this market and period.
 
 ### Periodic Earn Stats
-- `period_start_date`
-- `period_type`
+- `period_start_date`: (e.g., `2023-10-27`, `2023-W43`, or `ALL`)
+- `period_type`: (e.g., `daily`, `weekly`, `monthly`, `all`)
 - `chain`
 - `protocol`
-- `count`
+- `count`: The total count of earn actions for this protocol and period.
 
 ### Leaderboard
-- `week`
+- `week`: (e.g., `2023-W43`)
 - `user_address`
 - `xp`
 - `first_xp_timestamp`

--- a/notes/metrics_schema.md
+++ b/notes/metrics_schema.md
@@ -44,7 +44,7 @@ This index enables efficient queries for offline analytics jobs (e.g., "fetch al
 
 | GSI Name | GSI Partition Key | GSI Sort Key |
 | :--- | :--- | :--- |
-| `transactions-by-time-gsi` | `tx_type` (String) | `timestamp` (String) |
+| `transactions-by-time-gsi` | `tx_type` (String) | `timestamp` (Number) |
 
 ---
 


### PR DESCRIPTION
This PR is a bit of a mixed bag. Some schema updates, the analytics required list was updated, and the  leaderboard analytics queries were moved into their own file in anticipation of adding several other ones (user analytics, earn analytics, swap analytics, etc.). Minor changes to how metrics are captured were needed to accommodate the new analytics requirements.

State of affairs is in the next section along with the proposed changes to the analytics captured.

---



### Captured Analytics (Real-time)

This list includes metrics that can be pulled **instantly** from aggregated `STAT` items, making them suitable for a fast-loading public dashboard. The 'Description' column details the efficient query pattern.

| Metric Category | Metric Name | Description / Calculation (Based on Schema) | Chart Type | Status |
| :--- | :--- | :--- | :--- | :--- |
| **User & Audience** | **Total Users** | `Get` `STAT#all#ALL` item. <br> Read the **`new_users`** attribute. | KPI Scorecard | ❌ |
| **User & Audience** | New Users (Time-series) | `Get` `STAT#{period}#GENERAL` item. <br> Read the **`new_users`** attribute. | Line/Bar Chart | ❌ |
| **User & Audience** | Active Users (DAU/WAU/MAU) | `Get` `STAT#{period}#GENERAL` item. <br> Read the **`active_users`** attribute. | Line Chart | ❌ |
| **Overall Activity** | **Total Transactions** | `Get` `STAT#all#ALL` item. <br> Calculate **`swap_count + lending_count + earn_count`**. | KPI Scorecard | ❌ |
| **Overall Activity** | Transaction Volume (Time-series) | `Get` `STAT#{period}#GENERAL` item. <br> Calculate **`swap_count + lending_count + earn_count`**. | Line/Bar Chart | ❌ |
| **Overall Activity** | Activity Breakdown (Time-series) | `Get` `STAT#{period}#GENERAL` item. <br> Read **`swap_count`**, **`lending_count`**, and **`earn_count`** attributes. | Stacked Bar Chart | ❌ |
| **Overall Activity** | dApp Entrances (Time-series) | `Get` `STAT#{period}#GENERAL` item. <br> Read the **`dapp_entrances`** attribute. | Line/Bar Chart | ❌ |
| **Overall Activity** | Transactions per Active User | `Get` `STAT#{period}#GENERAL` item. <br> Calculate **`(swap_count + lending_count + earn_count) / active_users`**. | Line Chart / KPI | ❌ |
| **Swap Metrics** | **Total Swap Count** | `Get` `STAT#all#ALL` item. <br> Read the **`swap_count`** attribute. | KPI Scorecard | ❌ |
| **Swap Metrics** | Swap Routes (Chains) Breakdown | `Query` `PK = STAT#{period}` and `SK starts_with "SWAP#"`. <br> Aggregate results from all `periodic_swap_stats` items. | Sankey Diagram / Bar Chart | ❌ |
| **Swap Metrics** | Cross-Chain vs. Same-Chain | `Query` `PK = STAT#{period}` and `SK starts_with "SWAP#"`. <br> Backend logic parses the `SK` (`SWAP#{source}#{dest}`) to sum `count` for `source != dest` vs. `source == dest`. | Donut Chart | ❌ |
| **Lending Metrics** | **Total Lending Count** | `Get` `STAT#all#ALL` item. <br> Read the **`lending_count`** attribute. | KPI Scorecard | ❌ |
| **Lending Metrics** | Lending Market/Chain Breakdown | `Query` `PK = STAT#{period}` and `SK starts_with "LENDING#"`. <br> Backend logic parses the `SK` (`LENDING#{chain}#{market}`) to aggregate `count` by chain or market. | Bar Chart / Donut Chart | ❌ |
| **Earn Metrics** | **Total Earn Count** | `Get` `STAT#all#ALL` item. <br> Read the **`earn_count`** attribute. | KPI Scorecard | ❌ |
| **Earn Metrics** | Earn Protocol/Chain Breakdown | `Query` `PK = STAT#{period}` and `SK starts_with "EARN#"`. <br> Backend logic parses the `SK` (`EARN#{chain}#{protocol}`) to aggregate `count` by chain or protocol. | Bar Chart / Donut Chart | ❌ |
| **Leaderboard** | Weekly Leaderboard | `Query` the **`leaderboard-by-xp-gsi`** with `PK = LEADERBOARD#{current_week}`. | Table | ✅ |
| **Leaderboard** | Global Leaderboard | `Query` the **`global-leaderboard-by-xp-gsi`** with `PK = "GLOBAL"`. | Table | ✅ |

-----

### Expensive / Offline Analytics

This list includes metrics that **cannot** be answered by the real-time `STAT` items. They require full scans, GSI queries, or post-processing (e.g., with AWS Glue, Athena, or a batch Lambda) on the raw transaction data.

| Metric Category | Metric Name | Reason for Offline Calculation | Status |
| :--- | :--- | :--- | :--- |
| **User & Audience** | New User Growth Rate | Depends on "Total Users" (real-time) and periodic `new_users`, but calculation is typically done offline. | ❌ |
| **User & Audience** | Retention Cohorts | Requires finding users by `first_active_timestamp` and then checking their activity in subsequent periods. | ❌ |
| **Swap Metrics** | Swap Pair Breakdown (Tokens) | The `periodic_swap_stats` item is keyed by *chain*, not by `source_token_symbol` or `destination_token_symbol`. This requires querying the raw `swap` items. | ❌ |
| **Lending Metrics** | Lending Action Breakdown | The `periodic_lending_stats` item is keyed by `chain` and `market_name`, not by `action` (deposit, borrow, etc.). This requires querying the raw `lending` items. | ❌ |
| **Lending Metrics** | Lending Assets Breakdown | The `periodic_lending_stats` item does not include `token_symbol`. This requires querying the raw `lending` items. | ❌ |
| **Earn Metrics** | Earn Action Breakdown | The `periodic_earn_stats` item is keyed by `chain` and `protocol`, not by `action` (stake, unstake, etc.). This requires querying the raw `earn` items. | ❌ |
| **Earn Metrics** | Vault Breakdown | The `periodic_earn_stats` item does not include `vault_name`. This requires querying the raw `earn` items. | ❌ |