### PR TITLE
feature: extend analytics

### DIFF
--- a/lambda/src/endpoints/analytics/activity.py
+++ b/lambda/src/endpoints/analytics/activity.py
@@ -58,7 +58,7 @@ def get_periodic_activity_stats(body):
     {
         "queryType": "periodic_activity_stats",
         "period_type": "daily" | "weekly" | "monthly",
-        "limit": 7 | 4 | 54 | 12
+        "limit": 7,
     }
     """
     try:

--- a/lambda/src/endpoints/analytics/activity.py
+++ b/lambda/src/endpoints/analytics/activity.py
@@ -1,0 +1,150 @@
+import json
+from botocore.exceptions import ClientError
+from ...config import dynamodb, metrics_table
+from ...utils.utils import (
+    build_response,
+    get_past_periods,
+)
+
+
+def get_total_activity_stats(body):
+    """
+    Fetches the global, all-time activity stats from the STAT#all#ALL item.
+    Corresponds to the 'Total Transactions' KPI.
+    """
+    try:
+        response = metrics_table.get_item(Key={"PK": "STAT#all#ALL", "SK": "GENERAL"})
+
+        if "Item" not in response:
+            # Return zeros if the item hasn't been created yet
+            data = {
+                "total_transactions": 0,
+                "swap_count": 0,
+                "lending_count": 0,
+                "earn_count": 0,
+                "dapp_entrances": 0,
+                "total_users": 0,  # This is 'new_users' in the 'all' item
+            }
+            return build_response(200, data)
+
+        item = response["Item"]
+
+        # Get counts, defaulting to 0
+        swap_count = item.get("swap_count", 0)
+        lending_count = item.get("lending_count", 0)
+        earn_count = item.get("earn_count", 0)
+
+        data = {
+            "total_transactions": swap_count + lending_count + earn_count,
+            "swap_count": swap_count,
+            "lending_count": lending_count,
+            "earn_count": earn_count,
+            "dapp_entrances": item.get("dapp_entrances", 0),
+            "total_users": item.get("new_users", 0),
+        }
+
+        return build_response(200, data)
+
+    except ClientError as e:
+        print(f"Error fetching total activity stats: {e}")
+        return build_response(500, {"error": "Could not fetch total activity stats"})
+
+
+def get_periodic_activity_stats(body):
+    """
+    Fetches periodic activity stats for time-series charts.
+
+    Expected body:
+    {
+        "queryType": "periodic_activity_stats",
+        "period_type": "daily" | "weekly" | "monthly",
+        "limit": 7 | 4 | 54 | 12
+    }
+    """
+    try:
+        period_type = body.get("period_type", "daily")
+        limit = body.get("limit", 7)
+
+        # Basic Validation
+        if period_type not in ["daily", "weekly", "monthly"]:
+            return build_response(
+                400,
+                {
+                    "error": "Invalid 'period_type'. Must be 'daily', 'weekly', or 'monthly'."
+                },
+            )
+        if (
+            not isinstance(limit, int) or limit < 1 or limit > 90
+        ):  # 90-day/week/month max
+            return build_response(
+                400, {"error": "Invalid 'limit'. Must be an integer between 1 and 90."}
+            )
+
+        # 1. Get the list of past period start dates (e.g., ['2023-10-27', '2023-10-26', ...])
+        # This assumes a utility function similar to your get_time_periods
+        period_dates = get_past_periods(period_type, limit)
+
+        # 2. Prepare keys for BatchGetItem
+        keys_to_get = [
+            {"PK": f"STAT#{period_type}#{date}", "SK": "GENERAL"}
+            for date in period_dates
+        ]
+
+        if not keys_to_get:
+            return build_response(200, [])
+
+        # 3. Fetch items in a batch
+        response = dynamodb.batch_get_item(
+            RequestItems={
+                metrics_table.name: {
+                    "Keys": keys_to_get,
+                    "ProjectionExpression": "PK, swap_count, lending_count, earn_count, dapp_entrances, active_users",
+                }
+            }
+        )
+
+        # 4. Process the response into a map for easy lookup
+        items = response.get("Responses", {}).get(metrics_table.name, [])
+        stats_map = {item["PK"]: item for item in items}
+
+        # 5. Format the results, iterating over original dates to ensure order
+        #    and provide 0s for missing periods.
+        results = []
+        for date in period_dates:
+            pk = f"STAT#{period_type}#{date}"
+            item = stats_map.get(
+                pk, {}
+            )  # Get item or empty dict if no data for that day
+
+            # Get counts, defaulting to 0
+            swap = item.get("swap_count", 0)
+            lending = item.get("lending_count", 0)
+            earn = item.get("earn_count", 0)
+            active_users = item.get("active_users", 0)
+            dapp_entrances = item.get("dapp_entrances", 0)
+
+            total_tx = swap + lending + earn
+            tx_per_user = (total_tx / active_users) if active_users > 0 else 0
+
+            # This structure provides all data points for the "Overall Activity" charts
+            results.append(
+                {
+                    "period": date,
+                    "total_transactions": total_tx,
+                    "swap_count": swap,
+                    "lending_count": lending,
+                    "earn_count": earn,
+                    "dapp_entrances": dapp_entrances,
+                    "active_users": active_users,
+                    "transactions_per_active_user": tx_per_user,
+                }
+            )
+
+        return build_response(200, results)
+
+    except ClientError as e:
+        print(f"Error fetching periodic activity stats: {e}")
+        return build_response(500, {"error": "Could not fetch periodic activity stats"})
+    except Exception as e:
+        print(f"Unexpected error in get_periodic_activity_stats: {e}")
+        return build_response(500, {"error": str(e)})

--- a/lambda/src/endpoints/analytics/earn.py
+++ b/lambda/src/endpoints/analytics/earn.py
@@ -1,0 +1,172 @@
+import json
+from botocore.exceptions import ClientError
+from boto3.dynamodb.conditions import Key
+from ...config import metrics_table
+from ...utils.utils import build_response, get_past_periods
+
+
+def get_total_earn_stats(body):
+    """
+    Fetches the global, all-time total earn count and a
+    breakdown by chain and protocol.
+    This is used for top-level KPI scorecards and donut charts.
+
+    QueryType: "total_earn_stats"
+    Body: {}
+    """
+    try:
+        # 1. Query the entire STAT#all#ALL partition
+        # This efficiently gets both the GENERAL item and all EARN# items
+        response = metrics_table.query(
+            KeyConditionExpression=Key("PK").eq("STAT#all#ALL")
+        )
+
+        items = response.get("Items", [])
+
+        # 2. Process the results
+        total_earn_count = 0
+        by_chain = {}
+        by_protocol = {}
+        by_chain_protocol = {}
+
+        for item in items:
+            sk = item.get("SK")
+
+            # 2a. Get the total count from the GENERAL item
+            if sk == "GENERAL":
+                total_earn_count = item.get("earn_count", 0)
+
+            # 2b. Process breakdown items
+            elif sk and sk.startswith("EARN#"):
+                count = item.get("count", 0)
+                try:
+                    # SK format is "EARN#{chain}#{protocol}"
+                    parts = sk.split("#")
+                    if len(parts) == 3:
+                        chain = parts[1]
+                        protocol = parts[2]
+
+                        # Add to chain-protocol breakdown
+                        by_chain_protocol[f"{chain}#{protocol}"] = count
+
+                        # Aggregate by chain
+                        by_chain[chain] = by_chain.get(chain, 0) + count
+
+                        # Aggregate by protocol
+                        by_protocol[protocol] = by_protocol.get(protocol, 0) + count
+
+                except Exception as e:
+                    print(f"Warning: Could not parse all-time earn SK '{sk}': {e}")
+
+        # 3. Return the combined data
+        return build_response(
+            200,
+            {
+                "total_earn_count": total_earn_count,
+                "by_chain": by_chain,
+                "by_protocol": by_protocol,
+                "by_chain_protocol": by_chain_protocol,
+            },
+        )
+
+    except ClientError as e:
+        print(f"Error in get_total_earn_stats: {e}")
+        return build_response(500, {"error": "Could not fetch total earn stats"})
+
+
+def get_periodic_earn_stats(body):
+    """
+    Fetches periodic aggregated earn statistics for the last 'limit' periods.
+    This is used to populate time-series charts for earn activity breakdowns.
+
+    QueryType: "periodic_earn_stats"
+    Body: {
+        "period_type": "daily" | "weekly" | "monthly",
+        "limit": 8
+    }
+    """
+    try:
+        period_type = body.get("period_type", "daily")
+        try:
+            # Set reasonable bounds for limit to prevent abuse
+            limit = min(max(int(body.get("limit", 7)), 1), 90)
+        except (ValueError, TypeError):
+            limit = 7  # Default limit
+
+        if period_type not in ["daily", "weekly", "monthly"]:
+            return build_response(
+                400,
+                {
+                    "error": "Invalid period_type. Must be 'daily', 'weekly', or 'monthly'."
+                },
+            )
+
+        # 1. Get the list of period start dates (e.g., ["2023-10-27", "2023-10-26", ...])
+        period_starts = get_past_periods(period_type, limit)
+
+        results = []
+        # 2. Query for each period in the list
+        for period_start in period_starts:
+            pk = f"STAT#{period_type}#{period_start}"
+
+            # Query for all 'EARN#' items in the specific period partition
+            response = metrics_table.query(
+                KeyConditionExpression=Key("PK").eq(pk)
+                & Key("SK").begins_with("EARN#"),
+                ProjectionExpression="SK, #c",  # Only fetch the SK and count
+                ExpressionAttributeNames={"#c": "count"},
+            )
+
+            items = response.get("Items", [])
+
+            # --- 3. Aggregate stats for this single period ---
+            period_by_chain = {}
+            period_by_protocol = {}
+            period_by_chain_protocol = {}  # This is the raw data from DDB
+            period_total_earn = 0
+
+            for item in items:
+                sk = item.get("SK")
+                count = item.get("count", 0)
+
+                try:
+                    # SK format is "EARN#{chain}#{protocol}"
+                    parts = sk.split("#")
+                    if len(parts) == 3:
+                        chain = parts[1]
+                        protocol = parts[2]
+
+                        # 3a. Add to this period's total
+                        period_total_earn += count
+
+                        # 3b. Add to the chain-protocol breakdown
+                        period_by_chain_protocol[f"{chain}#{protocol}"] = count
+
+                        # 3c. Aggregate by chain
+                        period_by_chain[chain] = period_by_chain.get(chain, 0) + count
+
+                        # 3d. Aggregate by protocol
+                        period_by_protocol[protocol] = (
+                            period_by_protocol.get(protocol, 0) + count
+                        )
+
+                except Exception as e:
+                    print(f"Warning: Could not parse earn SK '{sk}' in {pk}: {e}")
+
+            # 4. Add this period's aggregated data to the main results list
+            results.append(
+                {
+                    "period_start": period_start,
+                    "total_earn_count": period_total_earn,
+                    "by_chain": period_by_chain,
+                    "by_protocol": period_by_protocol,
+                    "by_chain_protocol": period_by_chain_protocol,
+                }
+            )
+
+        # 5. Return the data in descending order (most recent first)
+        return build_response(200, {"period_type": period_type, "data": results})
+
+    except ClientError as e:
+        print(f"Error in get_periodic_earn_stats: {e}")
+        return build_response(500, {"error": "Could not fetch periodic earn stats"})

--- a/lambda/src/endpoints/analytics/handler.py
+++ b/lambda/src/endpoints/analytics/handler.py
@@ -3,6 +3,7 @@ from ...utils.utils import build_response
 
 from .leaderboard import get_leaderboard, get_user_entry
 from .users import get_total_users, get_periodic_user_stats
+from .activity import get_total_activity_stats, get_periodic_activity_stats
 
 
 def handle(event):
@@ -19,13 +20,20 @@ def handle(event):
                 400, {"error": "Request body must include 'queryType'"}
             )
 
-        # Route to the imported functions
-        elif query_type == "total_users":
+        # --- Users Routes ---
+        if query_type == "total_users":
             return get_total_users(body)
         elif query_type == "periodic_user_stats":
             return get_periodic_user_stats(body)
 
-        if query_type == "leaderboard":
+        # --- Activity Routes ---
+        elif query_type == "total_activity_stats":
+            return get_total_activity_stats(body)
+        elif query_type == "periodic_activity_stats":
+            return get_periodic_activity_stats(body)
+
+        # --- Leaderboard Routes ---
+        elif query_type == "leaderboard":
             return get_leaderboard(body)
         elif query_type == "user_leaderboard_entry":
             return get_user_entry(body)

--- a/lambda/src/endpoints/analytics/handler.py
+++ b/lambda/src/endpoints/analytics/handler.py
@@ -4,7 +4,8 @@ from ...utils.utils import build_response
 from .leaderboard import get_leaderboard, get_user_entry
 from .users import get_total_users, get_periodic_user_stats
 from .activity import get_total_activity_stats, get_periodic_activity_stats
-from .swap import get_total_swap_stats, get_periodic_swap_stats  # <-- ADDED IMPORT
+from .swap import get_total_swap_stats, get_periodic_swap_stats
+from .lending import get_total_lending_stats, get_periodic_lending_stats
 
 
 def handle(event):
@@ -38,6 +39,12 @@ def handle(event):
             return get_total_swap_stats(body)
         elif query_type == "periodic_swap_stats":
             return get_periodic_swap_stats(body)
+
+        # --- Lending Routes ---
+        elif query_type == "total_lending_stats":
+            return get_total_lending_stats(body)
+        elif query_type == "periodic_lending_stats":
+            return get_periodic_lending_stats(body)
 
         # --- Leaderboard Routes ---
         elif query_type == "leaderboard":

--- a/lambda/src/endpoints/analytics/handler.py
+++ b/lambda/src/endpoints/analytics/handler.py
@@ -2,6 +2,7 @@ import json
 from ...utils.utils import build_response
 
 from .leaderboard import get_leaderboard, get_user_entry
+from .users import get_total_users, get_periodic_user_stats
 
 
 def handle(event):
@@ -19,6 +20,11 @@ def handle(event):
             )
 
         # Route to the imported functions
+        elif query_type == "total_users":
+            return get_total_users(body)
+        elif query_type == "periodic_user_stats":
+            return get_periodic_user_stats(body)
+
         if query_type == "leaderboard":
             return get_leaderboard(body)
         elif query_type == "user_leaderboard_entry":

--- a/lambda/src/endpoints/analytics/handler.py
+++ b/lambda/src/endpoints/analytics/handler.py
@@ -4,6 +4,7 @@ from ...utils.utils import build_response
 from .leaderboard import get_leaderboard, get_user_entry
 from .users import get_total_users, get_periodic_user_stats
 from .activity import get_total_activity_stats, get_periodic_activity_stats
+from .swap import get_total_swap_stats, get_periodic_swap_stats  # <-- ADDED IMPORT
 
 
 def handle(event):
@@ -31,6 +32,12 @@ def handle(event):
             return get_total_activity_stats(body)
         elif query_type == "periodic_activity_stats":
             return get_periodic_activity_stats(body)
+
+        # --- Swap Routes ---
+        elif query_type == "total_swap_stats":
+            return get_total_swap_stats(body)
+        elif query_type == "periodic_swap_stats":
+            return get_periodic_swap_stats(body)
 
         # --- Leaderboard Routes ---
         elif query_type == "leaderboard":

--- a/lambda/src/endpoints/analytics/handler.py
+++ b/lambda/src/endpoints/analytics/handler.py
@@ -6,6 +6,7 @@ from .users import get_total_users, get_periodic_user_stats
 from .activity import get_total_activity_stats, get_periodic_activity_stats
 from .swap import get_total_swap_stats, get_periodic_swap_stats
 from .lending import get_total_lending_stats, get_periodic_lending_stats
+from .earn import get_total_earn_stats, get_periodic_earn_stats
 
 
 def handle(event):
@@ -45,6 +46,12 @@ def handle(event):
             return get_total_lending_stats(body)
         elif query_type == "periodic_lending_stats":
             return get_periodic_lending_stats(body)
+
+        # --- Earn Routes ---
+        elif query_type == "total_earn_stats":
+            return get_total_earn_stats(body)
+        elif query_type == "periodic_earn_stats":
+            return get_periodic_earn_stats(body)
 
         # --- Leaderboard Routes ---
         elif query_type == "leaderboard":

--- a/lambda/src/endpoints/analytics/leaderboard.py
+++ b/lambda/src/endpoints/analytics/leaderboard.py
@@ -8,12 +8,16 @@ from ...utils.utils import build_response, get_time_periods
 def get_leaderboard(payload):
     """
     Fetches paginated leaderboard data from the GSIs.
-    Payload:
-    {
+
+    QueryType: "get_leaderboard"
+    Payload: {
         "scope": "global" | "weekly",
-        "limit": 1000, // Optional, default 50, max 1000
-        "lastKey": { ... } // Optional, for pagination
+        "limit": 100,
+        "lastKey": {...}
     }
+
+    Returns:
+        Response with items array and lastKey for pagination
     """
     try:
         # Define a max limit to prevent abuse
@@ -93,11 +97,14 @@ def get_leaderboard(payload):
 def get_user_entry(payload):
     """
     Fetches the global and weekly leaderboard XP for a single user.
-    Note: This returns the user's XP, not their numerical rank.
-    Payload:
-    {
-        "user_address": "string" // Required
+
+    QueryType: "get_user_entry"
+    Payload: {
+        "user_address": "string"
     }
+
+    Returns:
+        Response with user_address, global_total_xp, and weekly_xp
     """
     try:
         user_address = payload.get("user_address")

--- a/lambda/src/endpoints/analytics/lending.py
+++ b/lambda/src/endpoints/analytics/lending.py
@@ -1,0 +1,135 @@
+import json
+from boto3.dynamodb.conditions import Key
+from ...config import metrics_table
+from ...utils.utils import build_response, get_past_periods
+
+
+def get_total_lending_stats(body):
+    """
+    Fetches all-time lending stats:
+    1. The single "Total Lending Count" KPI.
+    2. The all-time breakdown by chain/market.
+
+    QueryType: "total_lending_stats"
+    Body: {}
+    """
+    try:
+        pk_all = "STAT#all#ALL"
+
+        # 1. Get total lending count from the GENERAL item
+        # This fulfills the "Total Lending Count" KPI requirement.
+        response_general = metrics_table.get_item(
+            Key={"PK": pk_all, "SK": "GENERAL"}, ProjectionExpression="lending_count"
+        )
+        total_count = response_general.get("Item", {}).get("lending_count", 0)
+
+        # 2. Get all-time breakdown by querying for LENDING# items
+        # This fulfills the "Lending Market/Chain Breakdown" for an "all-time" view.
+        response_breakdown = metrics_table.query(
+            KeyConditionExpression=Key("PK").eq(pk_all)
+            & Key("SK").begins_with("LENDING#"),
+            ProjectionExpression="SK, #c",
+            ExpressionAttributeNames={"#c": "count"},
+        )
+
+        breakdown = []
+        for item in response_breakdown.get("Items", []):
+            try:
+                # SK is "LENDING#{chain}#{market_name}"
+                parts = item["SK"].split("#")
+                chain = parts[1]
+                market = parts[2]
+                count = item.get("count", 0)
+                breakdown.append({"chain": chain, "market": market, "count": count})
+            except (IndexError, TypeError):
+                # Log error but continue processing other items
+                print(f"Error parsing SK for total lending stats: {item.get('SK')}")
+                continue
+
+        return build_response(
+            200, {"total_lending_count": total_count, "breakdown": breakdown}
+        )
+
+    except Exception as e:
+        print(f"Error in get_total_lending_stats: {str(e)}")
+        return build_response(500, {"error": "Could not fetch total lending stats"})
+
+
+def get_periodic_lending_stats(body):
+    """
+    Fetches periodic lending stats (total count and breakdown) for the last 'limit' periods.
+    This fulfills the "Lending Market/Chain Breakdown" for periodic views (daily, weekly, monthly).
+
+    QueryType: "periodic_lending_stats"
+    Body: {
+        "period_type": "daily" | "weekly" | "monthly",
+        "limit": 7
+    }
+    """
+    try:
+        period_type = body.get("period_type", "daily")
+        try:
+            # Set reasonable bounds for limit to prevent abuse
+            limit = min(max(int(body.get("limit", 7)), 1), 90)
+        except (ValueError, TypeError):
+            limit = 7  # Default limit
+
+        if period_type not in ["daily", "weekly", "monthly"]:
+            return build_response(
+                400,
+                {
+                    "error": "Invalid period_type. Must be 'daily', 'weekly', or 'monthly'."
+                },
+            )
+
+        # Get the list of period start dates (e.g., ["2023-10-27", "2023-10-26", ...])
+        period_starts = get_past_periods(period_type, limit)
+
+        results = []
+        # Query for each period in the list
+        for period_start in period_starts:
+            pk = f"STAT#{period_type}#{period_start}"
+
+            # Query for all LENDING# items for this specific period
+            response = metrics_table.query(
+                KeyConditionExpression=Key("PK").eq(pk)
+                & Key("SK").begins_with("LENDING#"),
+                ProjectionExpression="SK, #c",
+                ExpressionAttributeNames={"#c": "count"},
+            )
+
+            period_breakdown = []
+            period_total = 0
+            for item in response.get("Items", []):
+                try:
+                    # SK is "LENDING#{chain}#{market_name}"
+                    parts = item["SK"].split("#")
+                    chain = parts[1]
+                    market = parts[2]
+                    count = item.get("count", 0)
+
+                    period_breakdown.append(
+                        {"chain": chain, "market": market, "count": count}
+                    )
+                    # We can calculate the period's total by summing the breakdown
+                    period_total += count
+                except (IndexError, TypeError):
+                    print(
+                        f"Error parsing SK for periodic lending stats: {item.get('SK')}"
+                    )
+                    continue
+
+            results.append(
+                {
+                    "period_start": period_start,
+                    "total_lending_count": period_total,
+                    "breakdown": period_breakdown,
+                }
+            )
+
+        # Return the data in descending order (most recent first)
+        return build_response(200, {"period_type": period_type, "data": results})
+
+    except Exception as e:
+        print(f"Error in get_periodic_lending_stats: {str(e)}")
+        return build_response(500, {"error": "Could not fetch periodic lending stats"})

--- a/lambda/src/endpoints/analytics/swap.py
+++ b/lambda/src/endpoints/analytics/swap.py
@@ -1,7 +1,8 @@
+import json
 from botocore.exceptions import ClientError
 from boto3.dynamodb.conditions import Key
 from ...config import metrics_table
-from ...utils.utils import build_response
+from ...utils.utils import build_response, get_past_periods
 
 
 def get_total_swap_stats(body):
@@ -13,6 +14,9 @@ def get_total_swap_stats(body):
     2. All 'SWAP#{direction}' items for a breakdown by route.
     It then aggregates this data to provide a total count, a route
     breakdown, and a cross-chain vs. same-chain summary.
+
+    QueryType: "total_swap_stats"
+    Body: {}
     """
     try:
         # Query for all items in the STAT#all#ALL partition
@@ -31,6 +35,7 @@ def get_total_swap_stats(body):
             sk = item.get("SK")
 
             if sk == "GENERAL":
+                # Get the master total swap count from the GENERAL item
                 total_swap_count = item.get("swap_count", 0)
 
             elif sk and sk.startswith("SWAP#"):
@@ -69,66 +74,90 @@ def get_total_swap_stats(body):
 
 def get_periodic_swap_stats(body):
     """
-    Fetches periodic aggregated swap statistics for a specific time period.
+    Fetches periodic aggregated swap statistics for the last 'limit' periods.
+    This is used to populate time-series charts.
 
-    Requires 'period_type' (daily, weekly, monthly) and 'start_date'
-    (YYYY-MM-DD) in the request body.
-
-    This function queries a single partition (e.g., 'STAT#daily#2023-10-27')
-    and reads all items starting with 'SWAP#' to build the analytics.
+    QueryType: "periodic_swap_stats"
+    Body: {
+        "period_type": "daily" | "weekly" | "monthly",
+        "limit": 7
+    }
     """
     try:
-        period_type = body.get("period_type")
-        start_date = body.get("start_date")
+        period_type = body.get("period_type", "daily")
+        try:
+            # Set reasonable bounds for limit to prevent abuse
+            limit = min(max(int(body.get("limit", 7)), 1), 90)
+        except (ValueError, TypeError):
+            limit = 7  # Default limit
 
-        if not period_type or not start_date:
+        if period_type not in ["daily", "weekly", "monthly"]:
             return build_response(
                 400,
-                {"error": "Missing required fields: 'period_type' and 'start_date'"},
+                {
+                    "error": "Invalid period_type. Must be 'daily', 'weekly', or 'monthly'."
+                },
             )
 
-        pk = f"STAT#{period_type}#{start_date}"
+        # Get the list of period start dates (e.g., ["2023-10-27", "2023-10-26", ...])
+        period_starts = get_past_periods(period_type, limit)
 
-        # Query for all 'SWAP#' items in the specific period partition
-        response = metrics_table.query(
-            KeyConditionExpression=Key("PK").eq(pk) & Key("SK").begins_with("SWAP#")
-        )
+        results = []
+        # Query for each period in the list
+        for period_start in period_starts:
+            pk = f"STAT#{period_type}#{period_start}"
 
-        items = response.get("Items", [])
+            # Query for all 'SWAP#' items in the specific period partition
+            response = metrics_table.query(
+                KeyConditionExpression=Key("PK").eq(pk)
+                & Key("SK").begins_with("SWAP#"),
+                ProjectionExpression="SK, #c",
+                ExpressionAttributeNames={"#c": "count"},
+            )
 
-        swap_routes = {}
-        cross_chain_count = 0
-        same_chain_count = 0
+            items = response.get("Items", [])
 
-        for item in items:
-            sk = item.get("SK")
+            # --- Aggregate stats for this single period ---
+            period_swap_routes = {}
+            period_cross_chain_count = 0
+            period_same_chain_count = 0
+            period_total_swaps = 0
 
-            try:
-                direction = sk.split("#", 1)[1]
-                count = item.get("count", 0)
+            for item in items:
+                sk = item.get("SK")
+                try:
+                    direction = sk.split("#", 1)[1]
+                    count = item.get("count", 0)
 
-                # 1. Add to swap_routes breakdown
-                swap_routes[direction] = count
+                    # 1. Add to this period's swap_routes breakdown
+                    period_swap_routes[direction] = count
 
-                # 2. Add to cross-chain vs. same-chain breakdown
-                chains = direction.split(",")
-                if len(chains) == 2:
-                    if chains[0] == chains[1]:
-                        same_chain_count += count
-                    else:
-                        cross_chain_count += count
-            except Exception as e:
-                print(f"Warning: Could not parse swap SK '{sk}' in {pk}: {e}")
+                    # 2. Sum for this period's total
+                    period_total_swaps += count
 
-        result = {
-            "period": start_date,
-            "period_type": period_type,
-            "swap_routes": swap_routes,
-            "cross_chain_count": cross_chain_count,
-            "same_chain_count": same_chain_count,
-        }
+                    # 3. Add to this period's cross-chain vs. same-chain
+                    chains = direction.split(",")
+                    if len(chains) == 2:
+                        if chains[0] == chains[1]:
+                            period_same_chain_count += count
+                        else:
+                            period_cross_chain_count += count
+                except Exception as e:
+                    print(f"Warning: Could not parse swap SK '{sk}' in {pk}: {e}")
 
-        return build_response(200, result)
+            # Add this period's aggregated data to the main results list
+            results.append(
+                {
+                    "period_start": period_start,
+                    "total_swap_count": period_total_swaps,
+                    "swap_routes": period_swap_routes,
+                    "cross_chain_count": period_cross_chain_count,
+                    "same_chain_count": period_same_chain_count,
+                }
+            )
+
+        # Return the data in descending order (most recent first)
+        return build_response(200, {"period_type": period_type, "data": results})
 
     except ClientError as e:
         print(f"Error in get_periodic_swap_stats: {e}")

--- a/lambda/src/endpoints/analytics/swap.py
+++ b/lambda/src/endpoints/analytics/swap.py
@@ -1,0 +1,135 @@
+from botocore.exceptions import ClientError
+from boto3.dynamodb.conditions import Key
+from ...config import metrics_table
+from ...utils.utils import build_response
+
+
+def get_total_swap_stats(body):
+    """
+    Fetches all-time aggregated swap statistics.
+
+    This function queries the single STAT#all#ALL partition to get:
+    1. The 'GENERAL' item for the overall total_swap_count.
+    2. All 'SWAP#{direction}' items for a breakdown by route.
+    It then aggregates this data to provide a total count, a route
+    breakdown, and a cross-chain vs. same-chain summary.
+    """
+    try:
+        # Query for all items in the STAT#all#ALL partition
+        response = metrics_table.query(
+            KeyConditionExpression=Key("PK").eq("STAT#all#ALL")
+        )
+
+        items = response.get("Items", [])
+
+        total_swap_count = 0
+        swap_routes = {}
+        cross_chain_count = 0
+        same_chain_count = 0
+
+        for item in items:
+            sk = item.get("SK")
+
+            if sk == "GENERAL":
+                total_swap_count = item.get("swap_count", 0)
+
+            elif sk and sk.startswith("SWAP#"):
+                try:
+                    direction = sk.split("#", 1)[1]
+                    count = item.get("count", 0)
+
+                    # 1. Add to swap_routes breakdown
+                    swap_routes[direction] = count
+
+                    # 2. Add to cross-chain vs. same-chain breakdown
+                    chains = direction.split(",")
+                    if len(chains) == 2:
+                        if chains[0] == chains[1]:
+                            same_chain_count += count
+                        else:
+                            cross_chain_count += count
+                except Exception as e:
+                    print(
+                        f"Warning: Could not parse swap SK '{sk}' in STAT#all#ALL: {e}"
+                    )
+
+        result = {
+            "total_swap_count": total_swap_count,
+            "swap_routes": swap_routes,
+            "cross_chain_count": cross_chain_count,
+            "same_chain_count": same_chain_count,
+        }
+
+        return build_response(200, result)
+
+    except ClientError as e:
+        print(f"Error in get_total_swap_stats: {e}")
+        return build_response(500, {"error": "Could not fetch total swap stats"})
+
+
+def get_periodic_swap_stats(body):
+    """
+    Fetches periodic aggregated swap statistics for a specific time period.
+
+    Requires 'period_type' (daily, weekly, monthly) and 'start_date'
+    (YYYY-MM-DD) in the request body.
+
+    This function queries a single partition (e.g., 'STAT#daily#2023-10-27')
+    and reads all items starting with 'SWAP#' to build the analytics.
+    """
+    try:
+        period_type = body.get("period_type")
+        start_date = body.get("start_date")
+
+        if not period_type or not start_date:
+            return build_response(
+                400,
+                {"error": "Missing required fields: 'period_type' and 'start_date'"},
+            )
+
+        pk = f"STAT#{period_type}#{start_date}"
+
+        # Query for all 'SWAP#' items in the specific period partition
+        response = metrics_table.query(
+            KeyConditionExpression=Key("PK").eq(pk) & Key("SK").begins_with("SWAP#")
+        )
+
+        items = response.get("Items", [])
+
+        swap_routes = {}
+        cross_chain_count = 0
+        same_chain_count = 0
+
+        for item in items:
+            sk = item.get("SK")
+
+            try:
+                direction = sk.split("#", 1)[1]
+                count = item.get("count", 0)
+
+                # 1. Add to swap_routes breakdown
+                swap_routes[direction] = count
+
+                # 2. Add to cross-chain vs. same-chain breakdown
+                chains = direction.split(",")
+                if len(chains) == 2:
+                    if chains[0] == chains[1]:
+                        same_chain_count += count
+                    else:
+                        cross_chain_count += count
+            except Exception as e:
+                print(f"Warning: Could not parse swap SK '{sk}' in {pk}: {e}")
+
+        result = {
+            "period": start_date,
+            "period_type": period_type,
+            "swap_routes": swap_routes,
+            "cross_chain_count": cross_chain_count,
+            "same_chain_count": same_chain_count,
+        }
+
+        return build_response(200, result)
+
+    except ClientError as e:
+        print(f"Error in get_periodic_swap_stats: {e}")
+        return build_response(500, {"error": "Could not fetch periodic swap stats"})

--- a/lambda/src/endpoints/analytics/users.py
+++ b/lambda/src/endpoints/analytics/users.py
@@ -1,0 +1,74 @@
+import json
+from botocore.exceptions import ClientError
+from ...config import metrics_table
+from ...utils.utils import build_response
+
+
+def get_total_users(body):
+    """
+    Fetches the all-time total user count.
+    Corresponds to: User & Audience -> Total Users
+    - Query: Get STAT#all#ALL, read `new_users`
+    """
+    try:
+        response = metrics_table.get_item(
+            Key={"PK": "STAT#all#ALL", "SK": "GENERAL"},
+            ProjectionExpression="new_users",
+        )
+
+        # Default to 0 if the item or attribute doesn't exist yet
+        item = response.get("Item", {})
+        total_users = item.get("new_users", 0)
+
+        return build_response(200, {"total_users": int(total_users)})
+
+    except ClientError as e:
+        print(f"Error getting total users: {e}")
+        return build_response(500, {"error": "Could not retrieve total user count"})
+
+
+def get_periodic_user_stats(body):
+    """
+    Fetches new and active users for a specific period (daily, weekly, monthly).
+    Corresponds to:
+    - User & Audience -> New Users (Time-series)
+    - User & Audience -> Active Users (DAU/WAU/MAU)
+    - Query: Get STAT#{period}#GENERAL, read `new_users`, `active_users`
+
+    Expected body:
+    {
+        "queryType": "periodic_user_stats",
+        "period_type": "daily" | "weekly" | "monthly",
+        "period_start_date": "YYYY-MM-DD",
+    }
+    """
+    try:
+        period_type = body.get("period_type")
+        period_start_date = body.get("period_start_date")
+
+        if not period_type or not period_start_date:
+            return build_response(
+                400,
+                {"error": "Request must include 'period_type' and 'period_start_date'"},
+            )
+
+        response = metrics_table.get_item(
+            Key={
+                "PK": f"STAT#{period_type}#{period_start_date}",
+                "SK": "GENERAL",
+            },
+            ProjectionExpression="new_users, active_users",
+        )
+
+        # Default to 0 if the item or attributes don't exist for the period
+        item = response.get("Item", {})
+        new_users = item.get("new_users", 0)
+        active_users = item.get("active_users", 0)
+
+        return build_response(
+            200, {"new_users": int(new_users), "active_users": int(active_users)}
+        )
+
+    except ClientError as e:
+        print(f"Error getting periodic user stats: {e}")
+        return build_response(500, {"error": "Could not retrieve periodic user stats"})

--- a/lambda/src/utils/utils.py
+++ b/lambda/src/utils/utils.py
@@ -117,3 +117,43 @@ def build_response(status_code, body):
         "body": json.dumps(body, cls=CustomDecimalEncoder).encode("utf-8"),
         "isBase64Encoded": True,
     }
+
+
+def validate_period_type(period_type):
+    """
+    Validates that the period_type is one of the allowed values.
+
+    Args:
+        period_type: The period type to validate
+
+    Returns:
+        tuple: (is_valid, error_response)
+               is_valid is True if valid, False otherwise
+               error_response is the response to return if invalid
+    """
+    if period_type not in ["daily", "weekly", "monthly"]:
+        return False, build_response(
+            400,
+            {"error": "Invalid period_type. Must be 'daily', 'weekly', or 'monthly'."},
+        )
+    return True, None
+
+
+def validate_and_sanitize_limit(limit, default=7, min_val=1, max_val=90):
+    """
+    Validates and sanitizes the limit parameter for analytics queries.
+
+    Args:
+        limit: The limit value to validate (can be string, int, or None)
+        default: Default value to use if limit is invalid
+        min_val: Minimum allowed value
+        max_val: Maximum allowed value
+
+    Returns:
+        int: Sanitized limit value within bounds
+    """
+    try:
+        # Set reasonable bounds for limit to prevent abuse
+        return min(max(int(limit), min_val), max_val)
+    except (ValueError, TypeError):
+        return default

--- a/notes/analytics_required.md
+++ b/notes/analytics_required.md
@@ -17,8 +17,8 @@ This list includes metrics that can be pulled **instantly** from aggregated `STA
 | **Swap Metrics** | Cross-Chain vs. Same-Chain | `Query` `PK = STAT#{period}` and `SK starts_with "SWAP#"`. <br> Backend logic parses the `SK` (`SWAP#{source}#{dest}`) to sum `count` for `source != dest` vs. `source == dest`. | Donut Chart | ✅ |
 | **Lending Metrics** | **Total Lending Count** | `Get` `STAT#all#ALL` item. <br> Read the **`lending_count`** attribute. | KPI Scorecard | ✅ |
 | **Lending Metrics** | Lending Market/Chain Breakdown | `Query` `PK = STAT#{period}` and `SK starts_with "LENDING#"`. <br> Backend logic parses the `SK` (`LENDING#{chain}#{market}`) to aggregate `count` by chain or market. | Bar Chart / Donut Chart | ✅ |
-| **Earn Metrics** | **Total Earn Count** | `Get` `STAT#all#ALL` item. <br> Read the **`earn_count`** attribute. | KPI Scorecard | ❌ |
-| **Earn Metrics** | Earn Protocol/Chain Breakdown | `Query` `PK = STAT#{period}` and `SK starts_with "EARN#"`. <br> Backend logic parses the `SK` (`EARN#{chain}#{protocol}`) to aggregate `count` by chain or protocol. | Bar Chart / Donut Chart | ❌ |
+| **Earn Metrics** | **Total Earn Count** | `Get` `STAT#all#ALL` item. <br> Read the **`earn_count`** attribute. | KPI Scorecard | ✅ |
+| **Earn Metrics** | Earn Protocol/Chain Breakdown | `Query` `PK = STAT#{period}` and `SK starts_with "EARN#"`. <br> Backend logic parses the `SK` (`EARN#{chain}#{protocol}`) to aggregate `count` by chain or protocol. | Bar Chart / Donut Chart | ✅ |
 | **Leaderboard** | Weekly Leaderboard | `Query` the **`leaderboard-by-xp-gsi`** with `PK = LEADERBOARD#{current_week}`. | Table | ✅ |
 | **Leaderboard** | Global Leaderboard | `Query` the **`global-leaderboard-by-xp-gsi`** with `PK = "GLOBAL"`. | Table | ✅ |
 

--- a/notes/analytics_required.md
+++ b/notes/analytics_required.md
@@ -15,8 +15,8 @@ This list includes metrics that can be pulled **instantly** from aggregated `STA
 | **Swap Metrics** | **Total Swap Count** | `Get` `STAT#all#ALL` item. <br> Read the **`swap_count`** attribute. | KPI Scorecard | ✅ |
 | **Swap Metrics** | Swap Routes (Chains) Breakdown | `Query` `PK = STAT#{period}` and `SK starts_with "SWAP#"`. <br> Aggregate results from all `periodic_swap_stats` items. | Sankey Diagram / Bar Chart | ✅ |
 | **Swap Metrics** | Cross-Chain vs. Same-Chain | `Query` `PK = STAT#{period}` and `SK starts_with "SWAP#"`. <br> Backend logic parses the `SK` (`SWAP#{source}#{dest}`) to sum `count` for `source != dest` vs. `source == dest`. | Donut Chart | ✅ |
-| **Lending Metrics** | **Total Lending Count** | `Get` `STAT#all#ALL` item. <br> Read the **`lending_count`** attribute. | KPI Scorecard | ❌ |
-| **Lending Metrics** | Lending Market/Chain Breakdown | `Query` `PK = STAT#{period}` and `SK starts_with "LENDING#"`. <br> Backend logic parses the `SK` (`LENDING#{chain}#{market}`) to aggregate `count` by chain or market. | Bar Chart / Donut Chart | ❌ |
+| **Lending Metrics** | **Total Lending Count** | `Get` `STAT#all#ALL` item. <br> Read the **`lending_count`** attribute. | KPI Scorecard | ✅ |
+| **Lending Metrics** | Lending Market/Chain Breakdown | `Query` `PK = STAT#{period}` and `SK starts_with "LENDING#"`. <br> Backend logic parses the `SK` (`LENDING#{chain}#{market}`) to aggregate `count` by chain or market. | Bar Chart / Donut Chart | ✅ |
 | **Earn Metrics** | **Total Earn Count** | `Get` `STAT#all#ALL` item. <br> Read the **`earn_count`** attribute. | KPI Scorecard | ❌ |
 | **Earn Metrics** | Earn Protocol/Chain Breakdown | `Query` `PK = STAT#{period}` and `SK starts_with "EARN#"`. <br> Backend logic parses the `SK` (`EARN#{chain}#{protocol}`) to aggregate `count` by chain or protocol. | Bar Chart / Donut Chart | ❌ |
 | **Leaderboard** | Weekly Leaderboard | `Query` the **`leaderboard-by-xp-gsi`** with `PK = LEADERBOARD#{current_week}`. | Table | ✅ |

--- a/notes/analytics_required.md
+++ b/notes/analytics_required.md
@@ -7,11 +7,11 @@ This list includes metrics that can be pulled **instantly** from aggregated `STA
 | **User & Audience** | **Total Users** | `Get` `STAT#all#ALL` item. <br> Read the **`new_users`** attribute. | KPI Scorecard | ✅ |
 | **User & Audience** | New Users (Time-series) | `Get` `STAT#{period}#GENERAL` item. <br> Read the **`new_users`** attribute. | Line/Bar Chart | ✅ |
 | **User & Audience** | Active Users (DAU/WAU/MAU) | `Get` `STAT#{period}#GENERAL` item. <br> Read the **`active_users`** attribute. | Line Chart | ✅ |
-| **Overall Activity** | **Total Transactions** | `Get` `STAT#all#ALL` item. <br> Calculate **`swap_count + lending_count + earn_count`**. | KPI Scorecard | ❌ |
-| **Overall Activity** | Transaction Volume (Time-series) | `Get` `STAT#{period}#GENERAL` item. <br> Calculate **`swap_count + lending_count + earn_count`**. | Line/Bar Chart | ❌ |
-| **Overall Activity** | Activity Breakdown (Time-series) | `Get` `STAT#{period}#GENERAL` item. <br> Read **`swap_count`**, **`lending_count`**, and **`earn_count`** attributes. | Stacked Bar Chart | ❌ |
-| **Overall Activity** | dApp Entrances (Time-series) | `Get` `STAT#{period}#GENERAL` item. <br> Read the **`dapp_entrances`** attribute. | Line/Bar Chart | ❌ |
-| **Overall Activity** | Transactions per Active User | `Get` `STAT#{period}#GENERAL` item. <br> Calculate **`(swap_count + lending_count + earn_count) / active_users`**. | Line Chart / KPI | ❌ |
+| **Overall Activity** | **Total Transactions** | `Get` `STAT#all#ALL` item. <br> Calculate **`swap_count + lending_count + earn_count`**. | KPI Scorecard | ✅ |
+| **Overall Activity** | Transaction Volume (Time-series) | `Get` `STAT#{period}#GENERAL` item. <br> Calculate **`swap_count + lending_count + earn_count`**. | Line/Bar Chart | ✅ |
+| **Overall Activity** | Activity Breakdown (Time-series) | `Get` `STAT#{period}#GENERAL` item. <br> Read **`swap_count`**, **`lending_count`**, and **`earn_count`** attributes. | Stacked Bar Chart | ✅ |
+| **Overall Activity** | dApp Entrances (Time-series) | `Get` `STAT#{period}#GENERAL` item. <br> Read the **`dapp_entrances`** attribute. | Line/Bar Chart | ✅ |
+| **Overall Activity** | Transactions per Active User | `Get` `STAT#{period}#GENERAL` item. <br> Calculate **`(swap_count + lending_count + earn_count) / active_users`**. | Line Chart / KPI | ✅ |
 | **Swap Metrics** | **Total Swap Count** | `Get` `STAT#all#ALL` item. <br> Read the **`swap_count`** attribute. | KPI Scorecard | ❌ |
 | **Swap Metrics** | Swap Routes (Chains) Breakdown | `Query` `PK = STAT#{period}` and `SK starts_with "SWAP#"`. <br> Aggregate results from all `periodic_swap_stats` items. | Sankey Diagram / Bar Chart | ❌ |
 | **Swap Metrics** | Cross-Chain vs. Same-Chain | `Query` `PK = STAT#{period}` and `SK starts_with "SWAP#"`. <br> Backend logic parses the `SK` (`SWAP#{source}#{dest}`) to sum `count` for `source != dest` vs. `source == dest`. | Donut Chart | ❌ |

--- a/notes/analytics_required.md
+++ b/notes/analytics_required.md
@@ -4,9 +4,9 @@ This list includes metrics that can be pulled **instantly** from aggregated `STA
 
 | Metric Category | Metric Name | Description / Calculation (Based on Schema) | Chart Type | Status |
 | :--- | :--- | :--- | :--- | :--- |
-| **User & Audience** | **Total Users** | `Get` `STAT#all#ALL` item. <br> Read the **`new_users`** attribute. | KPI Scorecard | ❌ |
-| **User & Audience** | New Users (Time-series) | `Get` `STAT#{period}#GENERAL` item. <br> Read the **`new_users`** attribute. | Line/Bar Chart | ❌ |
-| **User & Audience** | Active Users (DAU/WAU/MAU) | `Get` `STAT#{period}#GENERAL` item. <br> Read the **`active_users`** attribute. | Line Chart | ❌ |
+| **User & Audience** | **Total Users** | `Get` `STAT#all#ALL` item. <br> Read the **`new_users`** attribute. | KPI Scorecard | ✅ |
+| **User & Audience** | New Users (Time-series) | `Get` `STAT#{period}#GENERAL` item. <br> Read the **`new_users`** attribute. | Line/Bar Chart | ✅ |
+| **User & Audience** | Active Users (DAU/WAU/MAU) | `Get` `STAT#{period}#GENERAL` item. <br> Read the **`active_users`** attribute. | Line Chart | ✅ |
 | **Overall Activity** | **Total Transactions** | `Get` `STAT#all#ALL` item. <br> Calculate **`swap_count + lending_count + earn_count`**. | KPI Scorecard | ❌ |
 | **Overall Activity** | Transaction Volume (Time-series) | `Get` `STAT#{period}#GENERAL` item. <br> Calculate **`swap_count + lending_count + earn_count`**. | Line/Bar Chart | ❌ |
 | **Overall Activity** | Activity Breakdown (Time-series) | `Get` `STAT#{period}#GENERAL` item. <br> Read **`swap_count`**, **`lending_count`**, and **`earn_count`** attributes. | Stacked Bar Chart | ❌ |

--- a/notes/analytics_required.md
+++ b/notes/analytics_required.md
@@ -12,9 +12,9 @@ This list includes metrics that can be pulled **instantly** from aggregated `STA
 | **Overall Activity** | Activity Breakdown (Time-series) | `Get` `STAT#{period}#GENERAL` item. <br> Read **`swap_count`**, **`lending_count`**, and **`earn_count`** attributes. | Stacked Bar Chart | ✅ |
 | **Overall Activity** | dApp Entrances (Time-series) | `Get` `STAT#{period}#GENERAL` item. <br> Read the **`dapp_entrances`** attribute. | Line/Bar Chart | ✅ |
 | **Overall Activity** | Transactions per Active User | `Get` `STAT#{period}#GENERAL` item. <br> Calculate **`(swap_count + lending_count + earn_count) / active_users`**. | Line Chart / KPI | ✅ |
-| **Swap Metrics** | **Total Swap Count** | `Get` `STAT#all#ALL` item. <br> Read the **`swap_count`** attribute. | KPI Scorecard | ❌ |
-| **Swap Metrics** | Swap Routes (Chains) Breakdown | `Query` `PK = STAT#{period}` and `SK starts_with "SWAP#"`. <br> Aggregate results from all `periodic_swap_stats` items. | Sankey Diagram / Bar Chart | ❌ |
-| **Swap Metrics** | Cross-Chain vs. Same-Chain | `Query` `PK = STAT#{period}` and `SK starts_with "SWAP#"`. <br> Backend logic parses the `SK` (`SWAP#{source}#{dest}`) to sum `count` for `source != dest` vs. `source == dest`. | Donut Chart | ❌ |
+| **Swap Metrics** | **Total Swap Count** | `Get` `STAT#all#ALL` item. <br> Read the **`swap_count`** attribute. | KPI Scorecard | ✅ |
+| **Swap Metrics** | Swap Routes (Chains) Breakdown | `Query` `PK = STAT#{period}` and `SK starts_with "SWAP#"`. <br> Aggregate results from all `periodic_swap_stats` items. | Sankey Diagram / Bar Chart | ✅ |
+| **Swap Metrics** | Cross-Chain vs. Same-Chain | `Query` `PK = STAT#{period}` and `SK starts_with "SWAP#"`. <br> Backend logic parses the `SK` (`SWAP#{source}#{dest}`) to sum `count` for `source != dest` vs. `source == dest`. | Donut Chart | ✅ |
 | **Lending Metrics** | **Total Lending Count** | `Get` `STAT#all#ALL` item. <br> Read the **`lending_count`** attribute. | KPI Scorecard | ❌ |
 | **Lending Metrics** | Lending Market/Chain Breakdown | `Query` `PK = STAT#{period}` and `SK starts_with "LENDING#"`. <br> Backend logic parses the `SK` (`LENDING#{chain}#{market}`) to aggregate `count` by chain or market. | Bar Chart / Donut Chart | ❌ |
 | **Earn Metrics** | **Total Earn Count** | `Get` `STAT#all#ALL` item. <br> Read the **`earn_count`** attribute. | KPI Scorecard | ❌ |

--- a/tests/analytics_tests.md
+++ b/tests/analytics_tests.md
@@ -231,7 +231,63 @@ This event tests the `periodic_lending_stats` query for a **monthly** time-serie
 
 -----
 
-### 17\. Fetch Global Leaderboard (Limit 50)
+### 17\. Fetch All-Time Earn Stats (KPIs)
+
+This event tests the `total_earn_stats` query, which hits the `get_total_earn_stats` function. Based on your `earn.py` code, this should return an object containing the `total_earn_count`. 
+
+```json
+{
+  "path": "/analytics",
+  "httpMethod": "POST",
+  "body": "{\"queryType\": \"total_earn_stats\"}"
+}
+```
+
+-----
+
+### 18\. Fetch Periodic Earn Stats (Daily)
+
+This event tests the `periodic_earn_stats` query for a **daily** time-series. It hits the `get_periodic_earn_stats` function with a `limit`. It should return an **array** of objects, one for each of the last 7 days, containing the `period_start`, `total_earn_count`, and breakdowns (`by_chain`, `by_protocol`, etc.) for each day.
+
+```json
+{
+  "path": "/analytics",
+  "httpMethod": "POST",
+  "body": "{\"queryType\": \"periodic_earn_stats\", \"period_type\": \"daily\", \"limit\": 7}"
+}
+```
+
+-----
+
+### 19\. Fetch Periodic Earn Stats (Weekly)
+
+This event tests the `periodic_earn_stats` query for a **weekly** time-series. It hits the `get_periodic_earn_stats` function with a `limit`. It should return an **array** of objects, one for each of the last 8 weeks.
+
+```json
+{
+  "path": "/analytics",
+  "httpMethod": "POST",
+  "body": "{\"queryType\": \"periodic_earn_stats\", \"period_type\": \"weekly\", \"limit\": 8}"
+}
+```
+
+-----
+
+### 20\. Fetch Periodic Earn Stats (Monthly)
+
+This event tests the `periodic_earn_stats` query for a **monthly** time-series. It hits the `get_periodic_earn_stats` function with a `limit`. It should return an **array** of objects, one for each of the last 6 months.
+
+```json
+{
+  "path": "/analytics",
+  "httpMethod": "POST",
+  "body": "{\"queryType\": \"periodic_earn_stats\", \"period_type\": \"monthly\", \"limit\": 6}"
+}
+```
+
+-----
+
+### 21\. Fetch Global Leaderboard (Limit 50)
 
 This event tests the standard request for the global leaderboard, fetching the top 50 users.
 
@@ -245,7 +301,7 @@ This event tests the standard request for the global leaderboard, fetching the t
 
 -----
 
-### 18\. Fetch Weekly Leaderboard (Limit 50)
+### 22\. Fetch Weekly Leaderboard (Limit 50)
 
 This event tests the standard request for the weekly leaderboard, fetching the top 50 users for the current week.
 
@@ -259,7 +315,7 @@ This event tests the standard request for the weekly leaderboard, fetching the t
 
 -----
 
-### 19\. Fetch Specific User's Leaderboard Entry
+### 23\. Fetch Specific User's Leaderboard Entry
 
 This event tests the `user_leaderboard_entry` query. It should return a single JSON object containing the specified user's `global_total_xp` and `weekly_xp`.
 

--- a/tests/analytics_tests.md
+++ b/tests/analytics_tests.md
@@ -18,53 +18,43 @@ This event tests the `total_users` query, which hits the `get_total_users` funct
 
 -----
 
-### 2\. Fetch Daily New & Active Users (DAU)
+### 2\. Fetch Periodic User Stats Time-series (Daily)
 
-This event tests the `periodic_user_stats` query for a **daily** period. It hits the `get_periodic_user_stats` function and should return an object containing `new_users` and `active_users` for that specific day.
-
-```json
-{
-  "path": "/analytics",
-  "httpMethod": "POST",
-  "body": "{\"queryType\": \"periodic_user_stats\", \"period_type\": \"daily\", \"period_start_date\": \"2025-10-26\"}"
-}
-```
-
-and
+This event tests the `periodic_user_stats` query for a **daily** time-series. It hits the `get_periodic_user_stats` function and should return an **array** of objects, one for each of the last 7 days, containing `new_users` and `active_users`.
 
 ```json
 {
   "path": "/analytics",
   "httpMethod": "POST",
-  "body": "{\"queryType\": \"periodic_user_stats\", \"period_type\": \"daily\", \"period_start_date\": \"2025-10-27\"}"
+  "body": "{\"queryType\": \"periodic_user_stats\", \"period_type\": \"daily\", \"limit\": 7}"
 }
 ```
 
 -----
 
-### 3\. Fetch Weekly New & Active Users (WAU)
+### 3\. Fetch Periodic User Stats Time-series (Weekly)
 
-This event tests the `periodic_user_stats` query for a **weekly** period. It hits the `get_periodic_user_stats` function and should return `new_users` and `active_users` for that specific week.
+This event tests the `periodic_user_stats` query for a **weekly** time-series. It hits the `get_periodic_user_stats` function and should return an **array** of objects for the last 8 weeks.
 
 ```json
 {
   "path": "/analytics",
   "httpMethod": "POST",
-  "body": "{\"queryType\": \"periodic_user_stats\", \"period_type\": \"weekly\", \"period_start_date\": \"2025-10-20\"}"
+  "body": "{\"queryType\": \"periodic_user_stats\", \"period_type\": \"weekly\", \"limit\": 8}"
 }
 ```
 
 -----
 
-### 4\. Fetch Monthly New & Active Users (MAU)
+### 4\. Fetch Periodic User Stats Time-series (Monthly)
 
-This event tests the `periodic_user_stats` query for a **monthly** period. It hits the `get_periodic_user_stats` function and should return `new_users` and `active_users` for that specific month.
+This event tests the `periodic_user_stats` query for a **monthly** time-series. It hits the `get_periodic_user_stats` function and should return an **array** of objects for the last 6 months.
 
 ```json
 {
   "path": "/analytics",
   "httpMethod": "POST",
-  "body": "{\"queryType\": \"periodic_user_stats\", \"period_type\": \"monthly\", \"period_start_date\": \"2025-10-01\"}"
+  "body": "{\"queryType\": \"periodic_user_stats\", \"period_type\": \"monthly\", \"limit\": 6}"
 }
 ```
 

--- a/tests/analytics_tests.md
+++ b/tests/analytics_tests.md
@@ -126,7 +126,63 @@ This event tests the `periodic_activity_stats` query for a **monthly** time-seri
 
 -----
 
-### 9\. Fetch Global Leaderboard (Limit 50)
+### 9\. Fetch All-Time Swap Stats
+
+This event tests the `total_swap_stats` query, which hits the `get_total_swap_stats` function. It should return an object containing the `total_swap_count`, a `swap_routes` breakdown, and the `cross_chain_count` vs. `same_chain_count`.
+
+```json
+{
+  "path": "/analytics",
+  "httpMethod": "POST",
+  "body": "{\"queryType\": \"total_swap_stats\"}"
+}
+```
+
+-----
+
+### 10\. Fetch Periodic Swap Stats (Daily)
+
+This event tests the `periodic_swap_stats` query for a **daily** period. It hits the `get_periodic_swap_stats` function and should return the `swap_routes` breakdown and cross-chain vs. same-chain counts for that specific day.
+
+```json
+{
+  "path": "/analytics",
+  "httpMethod": "POST",
+  "body": "{\"queryType\": \"periodic_swap_stats\", \"period_type\": \"daily\", \"start_date\": \"2025-10-26\"}"
+}
+```
+
+-----
+
+### 11\. Fetch Periodic Swap Stats (Weekly)
+
+This event tests the `periodic_swap_stats` query for a **weekly** period.
+
+```json
+{
+  "path": "/analytics",
+  "httpMethod": "POST",
+  "body": "{\"queryType\": \"periodic_swap_stats\", \"period_type\": \"weekly\", \"start_date\": \"2025-10-20\"}"
+}
+```
+
+-----
+
+### 12\. Fetch Periodic Swap Stats (Monthly)
+
+This event tests the `periodic_swap_stats` query for a **monthly** period.
+
+```json
+{
+  "path": "/analytics",
+  "httpMethod": "POST",
+  "body": "{\"queryType\": \"periodic_swap_stats\", \"period_type\": \"monthly\", \"start_date\": \"2025-10-01\"}"
+}
+```
+
+-----
+
+### 13\. Fetch Global Leaderboard (Limit 50)
 
 This event tests the standard request for the global leaderboard, fetching the top 50 users.
 
@@ -140,7 +196,7 @@ This event tests the standard request for the global leaderboard, fetching the t
 
 -----
 
-### 10\. Fetch Weekly Leaderboard (Limit 50)
+### 14\. Fetch Weekly Leaderboard (Limit 50)
 
 This event tests the standard request for the weekly leaderboard, fetching the top 50 users for the current week.
 
@@ -154,7 +210,7 @@ This event tests the standard request for the weekly leaderboard, fetching the t
 
 -----
 
-### 11\. Fetch Specific User's Leaderboard Entry
+### 15\. Fetch Specific User's Leaderboard Entry
 
 This event tests the `user_leaderboard_entry` query. It should return a single JSON object containing the specified user's `global_total_xp` and `weekly_xp`.
 

--- a/tests/analytics_tests.md
+++ b/tests/analytics_tests.md
@@ -2,7 +2,73 @@
 
 These test events are designed to validate the functionality of the `/analytics` endpoint for both `leaderboard` and `user_leaderboard_entry` query types.
 
-### 1\. Fetch Global Leaderboard (Limit 50)
+-----
+
+### 1\. Fetch Total Users (All-Time)
+
+This event tests the `total_users` query, which hits the `get_total_users` function. It should return a single JSON object with the `total_users` count.
+
+```json
+{
+  "path": "/analytics",
+  "httpMethod": "POST",
+  "body": "{\"queryType\": \"total_users\"}"
+}
+```
+
+-----
+
+### 2\. Fetch Daily New & Active Users (DAU)
+
+This event tests the `periodic_user_stats` query for a **daily** period. It hits the `get_periodic_user_stats` function and should return an object containing `new_users` and `active_users` for that specific day.
+
+```json
+{
+  "path": "/analytics",
+  "httpMethod": "POST",
+  "body": "{\"queryType\": \"periodic_user_stats\", \"period_type\": \"daily\", \"period_start_date\": \"2025-10-26\"}"
+}
+```
+
+and
+
+```json
+{
+  "path": "/analytics",
+  "httpMethod": "POST",
+  "body": "{\"queryType\": \"periodic_user_stats\", \"period_type\": \"daily\", \"period_start_date\": \"2025-10-27\"}"
+}
+```
+
+-----
+
+### 3\. Fetch Weekly New & Active Users (WAU)
+
+This event tests the `periodic_user_stats` query for a **weekly** period. It hits the `get_periodic_user_stats` function and should return `new_users` and `active_users` for that specific week.
+
+```json
+{
+  "path": "/analytics",
+  "httpMethod": "POST",
+  "body": "{\"queryType\": \"periodic_user_stats\", \"period_type\": \"weekly\", \"period_start_date\": \"2025-10-20\"}"
+}
+```
+
+-----
+
+### 4\. Fetch Monthly New & Active Users (MAU)
+
+This event tests the `periodic_user_stats` query for a **monthly** period. It hits the `get_periodic_user_stats` function and should return `new_users` and `active_users` for that specific month.
+
+```json
+{
+  "path": "/analytics",
+  "httpMethod": "POST",
+  "body": "{\"queryType\": \"periodic_user_stats\", \"period_type\": \"monthly\", \"period_start_date\": \"2025-10-01\"}"
+}
+```
+
+### 5\. Fetch Global Leaderboard (Limit 50)
 
 This event tests the standard request for the global leaderboard, fetching the top 50 users.
 
@@ -16,7 +82,7 @@ This event tests the standard request for the global leaderboard, fetching the t
 
 -----
 
-### 2\. Fetch Weekly Leaderboard (Limit 50)
+### 6\. Fetch Weekly Leaderboard (Limit 50)
 
 This event tests the standard request for the weekly leaderboard, fetching the top 50 users for the current week.
 
@@ -30,7 +96,7 @@ This event tests the standard request for the weekly leaderboard, fetching the t
 
 -----
 
-### 3\. Fetch Specific User's Leaderboard Entry
+### 7\. Fetch Specific User's Leaderboard Entry
 
 This event tests the `user_leaderboard_entry` query. It should return a single JSON object containing the specified user's `global_total_xp` and `weekly_xp`.
 

--- a/tests/analytics_tests.md
+++ b/tests/analytics_tests.md
@@ -68,7 +68,65 @@ This event tests the `periodic_user_stats` query for a **monthly** period. It hi
 }
 ```
 
-### 5\. Fetch Global Leaderboard (Limit 50)
+-----
+
+### 5\. Fetch All-Time Activity Stats (KPIs)
+
+This event tests the `total_activity_stats` query, which hits the `get_total_activity_stats` function. It should return a single JSON object with all-time KPI scorecards (e.g., `total_transactions`, `dapp_entrances`, `total_users`).
+
+```json
+{
+  "path": "/analytics",
+  "httpMethod": "POST",
+  "body": "{\"queryType\": \"total_activity_stats\"}"
+}
+```
+
+-----
+
+### 6\. Fetch Periodic Activity Time-series (Daily)
+
+This event tests the `periodic_activity_stats` query for a **daily** time-series. It hits the `get_periodic_activity_stats` function with a `limit`. It should return an **array** of objects, one for each of the last 7 days, containing all metrics needed for the time-series charts (e.g., `total_transactions`, `swap_count`, `active_users`, `transactions_per_active_user`).
+
+```json
+{
+  "path": "/analytics",
+  "httpMethod": "POST",
+  "body": "{\"queryType\": \"periodic_activity_stats\", \"period_type\": \"daily\", \"limit\": 7}"
+}
+```
+
+-----
+
+### 7\. Fetch Periodic Activity Time-series (Weekly)
+
+This event tests the `periodic_activity_stats` query for a **weekly** time-series. It hits the `get_periodic_activity_stats` function. It should return an **array** of objects, one for each of the last 8 weeks.
+
+```json
+{
+  "path": "/analytics",
+  "httpMethod": "POST",
+  "body": "{\"queryType\": \"periodic_activity_stats\", \"period_type\": \"weekly\", \"limit\": 8}"
+}
+```
+
+-----
+
+### 8\. Fetch Periodic Activity Time-series (Monthly)
+
+This event tests the `periodic_activity_stats` query for a **monthly** time-series. It hits the `get_periodic_activity_stats` function. It should return an **array** of objects, one for each of the last 6 months.
+
+```json
+{
+  "path": "/analytics",
+  "httpMethod": "POST",
+  "body": "{\"queryType\": \"periodic_activity_stats\", \"period_type\": \"monthly\", \"limit\": 6}"
+}
+```
+
+-----
+
+### 9\. Fetch Global Leaderboard (Limit 50)
 
 This event tests the standard request for the global leaderboard, fetching the top 50 users.
 
@@ -82,7 +140,7 @@ This event tests the standard request for the global leaderboard, fetching the t
 
 -----
 
-### 6\. Fetch Weekly Leaderboard (Limit 50)
+### 10\. Fetch Weekly Leaderboard (Limit 50)
 
 This event tests the standard request for the weekly leaderboard, fetching the top 50 users for the current week.
 
@@ -96,7 +154,7 @@ This event tests the standard request for the weekly leaderboard, fetching the t
 
 -----
 
-### 7\. Fetch Specific User's Leaderboard Entry
+### 11\. Fetch Specific User's Leaderboard Entry
 
 This event tests the `user_leaderboard_entry` query. It should return a single JSON object containing the specified user's `global_total_xp` and `weekly_xp`.
 

--- a/tests/analytics_tests.md
+++ b/tests/analytics_tests.md
@@ -182,7 +182,49 @@ This event tests the `periodic_swap_stats` query for a **monthly** period.
 
 -----
 
-### 13\. Fetch Global Leaderboard (Limit 50)
+### 13\. Fetch All-Time Lending Stats (KPIs)
+
+This event tests the `total_lending_stats` query, which hits the `get_total_lending_stats` function. It should return an object containing the `total_lending_count` (for the KPI card) and an all-time `breakdown` array (for the donut chart).
+
+```json
+{
+  "path": "/analytics",
+  "httpMethod": "POST",
+  "body": "{\"queryType\": \"total_lending_stats\"}"
+}
+```
+
+-----
+
+### 14\. Fetch Periodic Lending Stats (Daily)
+
+This event tests the `periodic_lending_stats` query for a **daily** time-series. It hits the `get_periodic_lending_stats` function with a `limit`. It should return an **array** of objects, one for each of the last 7 days, containing the `period_start`, `total_lending_count`, and `breakdown` for each day.
+
+```json
+{
+  "path": "/analytics",
+  "httpMethod": "POST",
+  "body": "{\"queryType\": \"periodic_lending_stats\", \"period_type\": \"daily\", \"limit\": 7}"
+}
+```
+
+-----
+
+### 15\. Fetch Periodic Lending Stats (Weekly)
+
+This event tests the `periodic_lending_stats` query for a **weekly** time-series. It hits the `get_periodic_lending_stats` function with a `limit`. It should return an **array** of objects, one for each of the last 8 weeks.
+
+```json
+{
+  "path": "/analytics",
+  "httpMethod": "POST",
+  "body": "{\"queryType\": \"periodic_lending_stats\", \"period_type\": \"weekly\", \"limit\": 8}"
+}
+```
+
+-----
+
+### 16\. Fetch Global Leaderboard (Limit 50)
 
 This event tests the standard request for the global leaderboard, fetching the top 50 users.
 
@@ -196,7 +238,7 @@ This event tests the standard request for the global leaderboard, fetching the t
 
 -----
 
-### 14\. Fetch Weekly Leaderboard (Limit 50)
+### 17\. Fetch Weekly Leaderboard (Limit 50)
 
 This event tests the standard request for the weekly leaderboard, fetching the top 50 users for the current week.
 
@@ -210,7 +252,7 @@ This event tests the standard request for the weekly leaderboard, fetching the t
 
 -----
 
-### 15\. Fetch Specific User's Leaderboard Entry
+### 18\. Fetch Specific User's Leaderboard Entry
 
 This event tests the `user_leaderboard_entry` query. It should return a single JSON object containing the specified user's `global_total_xp` and `weekly_xp`.
 

--- a/tests/analytics_tests.md
+++ b/tests/analytics_tests.md
@@ -140,43 +140,46 @@ This event tests the `total_swap_stats` query, which hits the `get_total_swap_st
 
 -----
 
-### 10\. Fetch Periodic Swap Stats (Daily)
+### 10\. Fetch Periodic Swap Stats Time-series (Daily)
 
-This event tests the `periodic_swap_stats` query for a **daily** period. It hits the `get_periodic_swap_stats` function and should return the `swap_routes` breakdown and cross-chain vs. same-chain counts for that specific day.
+This event tests the `periodic_swap_stats` query for a **daily** time-series. It should return an **array** of objects, one for each of the last 7 days.
+
 
 ```json
 {
   "path": "/analytics",
   "httpMethod": "POST",
-  "body": "{\"queryType\": \"periodic_swap_stats\", \"period_type\": \"daily\", \"start_date\": \"2025-10-26\"}"
+  "body": "{\"queryType\": \"periodic_swap_stats\", \"period_type\": \"daily\", \"limit\": 7}"
 }
 ```
 
 -----
 
-### 11\. Fetch Periodic Swap Stats (Weekly)
+### 11\. Fetch Periodic Swap Stats Time-series (Weekly)
 
-This event tests the `periodic_swap_stats` query for a **weekly** period.
+This event tests the `periodic_swap_stats` query for a **weekly** time-series. It should return an **array** of objects, one for each of the last 8 weeks.
+
 
 ```json
 {
   "path": "/analytics",
   "httpMethod": "POST",
-  "body": "{\"queryType\": \"periodic_swap_stats\", \"period_type\": \"weekly\", \"start_date\": \"2025-10-20\"}"
+  "body": "{\"queryType\": \"periodic_swap_stats\", \"period_type\": \"weekly\", \"limit\": 8}"
 }
 ```
 
 -----
 
-### 12\. Fetch Periodic Swap Stats (Monthly)
+### 12\. Fetch Periodic Swap Stats Time-series (Monthly)
 
-This event tests the `periodic_swap_stats` query for a **monthly** period.
+This event tests the `periodic_swap_stats` query for a **monthly** time-series. It should return an **array** of objects, one for each of the last 6 months.
+
 
 ```json
 {
   "path": "/analytics",
   "httpMethod": "POST",
-  "body": "{\"queryType\": \"periodic_swap_stats\", \"period_type\": \"monthly\", \"start_date\": \"2025-10-01\"}"
+  "body": "{\"queryType\": \"periodic_swap_stats\", \"period_type\": \"monthly\", \"limit\": 6}"
 }
 ```
 
@@ -224,7 +227,21 @@ This event tests the `periodic_lending_stats` query for a **weekly** time-series
 
 -----
 
-### 16\. Fetch Global Leaderboard (Limit 50)
+### 16\. Fetch Periodic Lending Stats (Monthly)
+
+This event tests the `periodic_lending_stats` query for a **monthly** time-series. It hits the `get_periodic_lending_stats` function with a `limit`. It should return an **array** of objects, one for each of the last 6 months.
+
+```json
+{
+  "path": "/analytics",
+  "httpMethod": "POST",
+  "body": "{\"queryType\": \"periodic_lending_stats\", \"period_type\": \"monthly\", \"limit\": 6}"
+}
+```
+
+-----
+
+### 17\. Fetch Global Leaderboard (Limit 50)
 
 This event tests the standard request for the global leaderboard, fetching the top 50 users.
 
@@ -238,7 +255,7 @@ This event tests the standard request for the global leaderboard, fetching the t
 
 -----
 
-### 17\. Fetch Weekly Leaderboard (Limit 50)
+### 18\. Fetch Weekly Leaderboard (Limit 50)
 
 This event tests the standard request for the weekly leaderboard, fetching the top 50 users for the current week.
 
@@ -252,7 +269,7 @@ This event tests the standard request for the weekly leaderboard, fetching the t
 
 -----
 
-### 18\. Fetch Specific User's Leaderboard Entry
+### 19\. Fetch Specific User's Leaderboard Entry
 
 This event tests the `user_leaderboard_entry` query. It should return a single JSON object containing the specified user's `global_total_xp` and `weekly_xp`.
 


### PR DESCRIPTION
This PR is concerned with implementing required analytics to track users & audience, activity breakdown, and swap, lending, and earn analytics. The next section outlines what has been captured. 

---

### Captured Analytics (Real-time)

This list includes metrics that can be pulled **instantly** from aggregated `STAT` items, making them suitable for a fast-loading public dashboard. The 'Description' column details the efficient query pattern.

| Metric Category | Metric Name | Description / Calculation (Based on Schema) | Chart Type | Status |
| :--- | :--- | :--- | :--- | :--- |
| **User & Audience** | **Total Users** | `Get` `STAT#all#ALL` item. <br> Read the **`new_users`** attribute. | KPI Scorecard | ✅ |
| **User & Audience** | New Users (Time-series) | `Get` `STAT#{period}#GENERAL` item. <br> Read the **`new_users`** attribute. | Line/Bar Chart | ✅ |
| **User & Audience** | Active Users (DAU/WAU/MAU) | `Get` `STAT#{period}#GENERAL` item. <br> Read the **`active_users`** attribute. | Line Chart | ✅ |
| **Overall Activity** | **Total Transactions** | `Get` `STAT#all#ALL` item. <br> Calculate **`swap_count + lending_count + earn_count`**. | KPI Scorecard | ✅ |
| **Overall Activity** | Transaction Volume (Time-series) | `Get` `STAT#{period}#GENERAL` item. <br> Calculate **`swap_count + lending_count + earn_count`**. | Line/Bar Chart | ✅ |
| **Overall Activity** | Activity Breakdown (Time-series) | `Get` `STAT#{period}#GENERAL` item. <br> Read **`swap_count`**, **`lending_count`**, and **`earn_count`** attributes. | Stacked Bar Chart | ✅ |
| **Overall Activity** | dApp Entrances (Time-series) | `Get` `STAT#{period}#GENERAL` item. <br> Read the **`dapp_entrances`** attribute. | Line/Bar Chart | ✅ |
| **Overall Activity** | Transactions per Active User | `Get` `STAT#{period}#GENERAL` item. <br> Calculate **`(swap_count + lending_count + earn_count) / active_users`**. | Line Chart / KPI | ✅ |
| **Swap Metrics** | **Total Swap Count** | `Get` `STAT#all#ALL` item. <br> Read the **`swap_count`** attribute. | KPI Scorecard | ✅ |
| **Swap Metrics** | Swap Routes (Chains) Breakdown | `Query` `PK = STAT#{period}` and `SK starts_with "SWAP#"`. <br> Aggregate results from all `periodic_swap_stats` items. | Sankey Diagram / Bar Chart | ✅ |
| **Swap Metrics** | Cross-Chain vs. Same-Chain | `Query` `PK = STAT#{period}` and `SK starts_with "SWAP#"`. <br> Backend logic parses the `SK` (`SWAP#{source}#{dest}`) to sum `count` for `source != dest` vs. `source == dest`. | Donut Chart | ✅ |
| **Lending Metrics** | **Total Lending Count** | `Get` `STAT#all#ALL` item. <br> Read the **`lending_count`** attribute. | KPI Scorecard | ✅ |
| **Lending Metrics** | Lending Market/Chain Breakdown | `Query` `PK = STAT#{period}` and `SK starts_with "LENDING#"`. <br> Backend logic parses the `SK` (`LENDING#{chain}#{market}`) to aggregate `count` by chain or market. | Bar Chart / Donut Chart | ✅ |
| **Earn Metrics** | **Total Earn Count** | `Get` `STAT#all#ALL` item. <br> Read the **`earn_count`** attribute. | KPI Scorecard | ✅ |
| **Earn Metrics** | Earn Protocol/Chain Breakdown | `Query` `PK = STAT#{period}` and `SK starts_with "EARN#"`. <br> Backend logic parses the `SK` (`EARN#{chain}#{protocol}`) to aggregate `count` by chain or protocol. | Bar Chart / Donut Chart | ✅ |
| **Leaderboard** | Weekly Leaderboard | `Query` the **`leaderboard-by-xp-gsi`** with `PK = LEADERBOARD#{current_week}`. | Table | ✅ |
| **Leaderboard** | Global Leaderboard | `Query` the **`global-leaderboard-by-xp-gsi`** with `PK = "GLOBAL"`. | Table | ✅ |

-----

### Expensive / Offline Analytics

This list includes metrics that **cannot** be answered by the real-time `STAT` items. They require full scans, GSI queries, or post-processing (e.g., with AWS Glue, Athena, or a batch Lambda) on the raw transaction data.

| Metric Category | Metric Name | Reason for Offline Calculation | Status |
| :--- | :--- | :--- | :--- |
| **User & Audience** | New User Growth Rate | Depends on "Total Users" (real-time) and periodic `new_users`, but calculation is typically done offline. | ❌ |
| **User & Audience** | Retention Cohorts | Requires finding users by `first_active_timestamp` and then checking their activity in subsequent periods. | ❌ |
| **Swap Metrics** | Swap Pair Breakdown (Tokens) | The `periodic_swap_stats` item is keyed by *chain*, not by `source_token_symbol` or `destination_token_symbol`. This requires querying the raw `swap` items. | ❌ |
| **Lending Metrics** | Lending Action Breakdown | The `periodic_lending_stats` item is keyed by `chain` and `market_name`, not by `action` (deposit, borrow, etc.). This requires querying the raw `lending` items. | ❌ |
| **Lending Metrics** | Lending Assets Breakdown | The `periodic_lending_stats` item does not include `token_symbol`. This requires querying the raw `lending` items. | ❌ |
| **Earn Metrics** | Earn Action Breakdown | The `periodic_earn_stats` item is keyed by `chain` and `protocol`, not by `action` (stake, unstake, etc.). This requires querying the raw `earn` items. | ❌ |
| **Earn Metrics** | Vault Breakdown | The `periodic_earn_stats` item does not include `vault_name`. This requires querying the raw `earn` items. | ❌ |