### PR TITLE
feat: gate analytics

### DIFF
--- a/lambda/src/config.py
+++ b/lambda/src/config.py
@@ -14,3 +14,4 @@ BUCKET_DURATION = 300  # 5 minutes in seconds
 
 # Special key for tracking the last database reset (Note: Not used in current code)
 RESET_TRACKER_KEY = "daily_reset_tracker"
+ANALYTICS_API_KEY = os.environ.get("ANALYTICS_API_KEY", None)

--- a/tests/analytics_tests.md
+++ b/tests/analytics_tests.md
@@ -2,6 +2,16 @@
 
 These test events are designed to validate the functionality of the `/analytics` endpoint for both `leaderboard` and `user_leaderboard_entry` query types.
 
+All protected test events **must** include a `headers` object with a valid API key to pass. Public tests do not require this header.
+
+**Example `headers` block to add:**
+
+```json
+  "headers": {
+    "x-api-key": "API_KEY_GOES_HERE"
+  },
+```
+
 -----
 
 ### 1\. Fetch Total Users (All-Time)


### PR DESCRIPTION
This PR enforces an API requirement for all analytics endpoints apart from the leaderboard.

---

<img width="748" height="243" alt="image" src="https://github.com/user-attachments/assets/60b0d535-53f5-401f-8346-850e21c3e9e0" />

vs

<img width="1132" height="189" alt="image" src="https://github.com/user-attachments/assets/629179fe-245b-4598-b77d-fcd0f9479ad1" />

with the `x-api-key` header.
